### PR TITLE
feat: componentes do roteiro + recharts/lucide + pacotes de créditos atualizados

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,11 +10,13 @@
       "dependencies": {
         "firebase": "^12.10.0",
         "html2pdf.js": "^0.10.2",
+        "lucide-react": "^1.8.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-force-graph-2d": "^1.25.0",
         "react-helmet-async": "^2.0.5",
-        "react-router-dom": "^7.13.1"
+        "react-router-dom": "^7.13.1",
+        "recharts": "^3.8.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
@@ -1312,6 +1314,42 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.9",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.9.tgz",
@@ -1405,9 +1443,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1425,9 +1460,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1445,9 +1477,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1465,9 +1494,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1485,9 +1511,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1505,9 +1528,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1590,6 +1610,18 @@
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
       "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
@@ -1751,9 +1783,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1775,9 +1804,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1799,9 +1825,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1823,9 +1846,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1998,9 +2018,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2018,9 +2035,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2038,9 +2052,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2058,9 +2069,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2166,6 +2174,69 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2228,6 +2299,12 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.0",
@@ -2513,6 +2590,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2702,6 +2788,15 @@
       "integrity": "sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==",
       "license": "MIT"
     },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-quadtree": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
@@ -2745,6 +2840,18 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -2835,6 +2942,12 @@
         }
       }
     },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2888,6 +3001,16 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/es6-promise": {
       "version": "4.2.8",
@@ -3100,6 +3223,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3434,6 +3563,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -3816,9 +3955,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3840,9 +3976,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3864,9 +3997,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3888,9 +4018,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4007,6 +4134,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.8.0.tgz",
+      "integrity": "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {
@@ -4380,6 +4516,29 @@
         "react": ">=16.13.1"
       }
     },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-router": {
       "version": "7.13.1",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.1.tgz",
@@ -4418,6 +4577,51 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
@@ -4433,6 +4637,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -4678,6 +4888,12 @@
         "utrie": "^1.0.2"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinycolor2": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
@@ -4767,6 +4983,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/utrie": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
@@ -4774,6 +4999,28 @@
       "license": "MIT",
       "dependencies": {
         "base64-arraybuffer": "^1.0.2"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,11 +12,13 @@
   "dependencies": {
     "firebase": "^12.10.0",
     "html2pdf.js": "^0.10.2",
+    "lucide-react": "^1.8.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-force-graph-2d": "^1.25.0",
     "react-helmet-async": "^2.0.5",
-    "react-router-dom": "^7.13.1"
+    "react-router-dom": "^7.13.1",
+    "recharts": "^3.8.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/frontend/src/components/AlertaForense.jsx
+++ b/frontend/src/components/AlertaForense.jsx
@@ -1,0 +1,80 @@
+import { AlertTriangle, ShieldAlert, ShieldCheck } from "lucide-react";
+
+/**
+ * AlertaForense — card de alerta com severidade (red/yellow/green).
+ *
+ * Props:
+ *   severidade: "red" | "yellow" | "green"
+ *   titulo: string
+ *   descricao: string
+ *   detalhes?: string (texto expandido)
+ */
+const CONFIG = {
+  red: {
+    bg: "#fef2f2",
+    border: "#fca5a5",
+    color: "#dc2626",
+    icon: ShieldAlert,
+    label: "Alerta Crítico",
+  },
+  yellow: {
+    bg: "#fffbeb",
+    border: "#fcd34d",
+    color: "#d97706",
+    icon: AlertTriangle,
+    label: "Atenção",
+  },
+  green: {
+    bg: "#f0fdf4",
+    border: "#86efac",
+    color: "#16a34a",
+    icon: ShieldCheck,
+    label: "Boa governança",
+  },
+};
+
+export default function AlertaForense({ severidade = "yellow", titulo, descricao, detalhes }) {
+  const cfg = CONFIG[severidade] || CONFIG.yellow;
+  const Icon = cfg.icon;
+
+  return (
+    <div
+      style={{
+        background: cfg.bg,
+        border: `1.5px solid ${cfg.border}`,
+        borderRadius: 12,
+        padding: "16px 20px",
+        display: "flex",
+        gap: 14,
+        alignItems: "flex-start",
+      }}
+    >
+      <Icon size={22} color={cfg.color} style={{ flexShrink: 0, marginTop: 2 }} />
+      <div style={{ flex: 1 }}>
+        <p
+          style={{
+            fontSize: 11,
+            fontWeight: 700,
+            textTransform: "uppercase",
+            letterSpacing: "0.06em",
+            color: cfg.color,
+            margin: "0 0 4px",
+          }}
+        >
+          {cfg.label}
+        </p>
+        <p style={{ fontSize: 15, fontWeight: 600, color: "#0f172a", margin: "0 0 4px" }}>
+          {titulo}
+        </p>
+        <p style={{ fontSize: 13, color: "#475569", margin: 0, lineHeight: 1.5 }}>
+          {descricao}
+        </p>
+        {detalhes && (
+          <p style={{ fontSize: 12, color: "#64748b", margin: "8px 0 0", lineHeight: 1.5 }}>
+            {detalhes}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/CreditBadge.jsx
+++ b/frontend/src/components/CreditBadge.jsx
@@ -1,0 +1,38 @@
+import { Coins } from "lucide-react";
+import { Link } from "react-router-dom";
+
+/**
+ * CreditBadge — saldo de créditos exibido no header/navbar.
+ * Clicável: redireciona para /usuario.
+ *
+ * Props:
+ *   credits: number (saldo total)
+ *   compact?: boolean (versão menor para mobile)
+ */
+export default function CreditBadge({ credits, compact = false }) {
+  const saldo = typeof credits === "number" ? credits : 0;
+
+  return (
+    <Link
+      to="/usuario"
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: compact ? 4 : 6,
+        background: "rgba(1,105,111,0.1)",
+        color: "#01696f",
+        borderRadius: 20,
+        padding: compact ? "4px 10px" : "5px 14px",
+        fontWeight: 700,
+        fontSize: compact ? 12 : 14,
+        textDecoration: "none",
+        transition: "background 0.15s",
+        whiteSpace: "nowrap",
+      }}
+      title={`${saldo} créditos disponíveis`}
+    >
+      <Coins size={compact ? 14 : 16} />
+      {saldo.toLocaleString("pt-BR")}
+    </Link>
+  );
+}

--- a/frontend/src/components/EmptyState.jsx
+++ b/frontend/src/components/EmptyState.jsx
@@ -1,0 +1,78 @@
+import { SearchX } from "lucide-react";
+import { Link } from "react-router-dom";
+
+/**
+ * EmptyState — estado vazio com ícone, mensagem e CTA opcional.
+ *
+ * Props:
+ *   titulo: string
+ *   descricao?: string
+ *   ctaLabel?: string
+ *   ctaTo?: string (rota React Router)
+ *   ctaOnClick?: () => void
+ *   icon?: React component
+ */
+export default function EmptyState({
+  titulo = "Nenhum resultado",
+  descricao,
+  ctaLabel,
+  ctaTo,
+  ctaOnClick,
+  icon: Icon = SearchX,
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: "48px 24px",
+        textAlign: "center",
+      }}
+    >
+      <Icon size={48} color="#cbd5e1" style={{ marginBottom: 16 }} />
+      <h3 style={{ fontSize: 18, fontWeight: 700, color: "#334155", margin: "0 0 6px" }}>
+        {titulo}
+      </h3>
+      {descricao && (
+        <p style={{ fontSize: 14, color: "#64748b", margin: "0 0 20px", maxWidth: 360 }}>
+          {descricao}
+        </p>
+      )}
+      {ctaLabel && ctaTo && (
+        <Link
+          to={ctaTo}
+          style={{
+            background: "#01696f",
+            color: "#fff",
+            padding: "10px 24px",
+            borderRadius: 10,
+            fontWeight: 600,
+            fontSize: 14,
+            textDecoration: "none",
+          }}
+        >
+          {ctaLabel}
+        </Link>
+      )}
+      {ctaLabel && ctaOnClick && !ctaTo && (
+        <button
+          onClick={ctaOnClick}
+          style={{
+            background: "#01696f",
+            color: "#fff",
+            padding: "10px 24px",
+            borderRadius: 10,
+            fontWeight: 600,
+            fontSize: 14,
+            border: "none",
+            cursor: "pointer",
+          }}
+        >
+          {ctaLabel}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/ScoreBadge.jsx
+++ b/frontend/src/components/ScoreBadge.jsx
@@ -1,0 +1,55 @@
+/**
+ * ScoreBadge — badge colorido com score numérico de transparência (0-100).
+ *
+ * Score < 30 → RISCO ALTO (vermelho)
+ * Score 30-60 → ATENÇÃO (amarelo)
+ * Score > 60 → REGULAR (verde)
+ * Score > 85 → EXEMPLAR (azul)
+ */
+export default function ScoreBadge({ score, size = "md" }) {
+  const s = typeof score === "number" ? score : null;
+
+  let bg, color, label;
+  if (s === null || isNaN(s)) {
+    bg = "#e2e8f0"; color = "#64748b"; label = "N/D";
+  } else if (s > 85) {
+    bg = "#dbeafe"; color = "#1d4ed8"; label = "Exemplar";
+  } else if (s > 60) {
+    bg = "#dcfce7"; color = "#16a34a"; label = "Regular";
+  } else if (s >= 30) {
+    bg = "#fef9c3"; color = "#d97706"; label = "Atenção";
+  } else {
+    bg = "#fee2e2"; color = "#dc2626"; label = "Risco Alto";
+  }
+
+  const sizes = {
+    sm: { fontSize: 13, padding: "3px 10px", gap: 4 },
+    md: { fontSize: 15, padding: "5px 14px", gap: 6 },
+    lg: { fontSize: 20, padding: "8px 20px", gap: 8 },
+  };
+  const sz = sizes[size] || sizes.md;
+
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: sz.gap,
+        background: bg,
+        color,
+        fontWeight: 700,
+        borderRadius: 8,
+        padding: sz.padding,
+        fontSize: sz.fontSize,
+        lineHeight: 1,
+        whiteSpace: "nowrap",
+      }}
+      title={`Score de transparência: ${s ?? "indisponível"} — ${label}`}
+    >
+      {s !== null ? s.toFixed(0) : "–"}
+      <span style={{ fontWeight: 500, fontSize: sz.fontSize * 0.75, opacity: 0.85 }}>
+        {label}
+      </span>
+    </span>
+  );
+}

--- a/frontend/src/pages/CreditosPage.jsx
+++ b/frontend/src/pages/CreditosPage.jsx
@@ -6,48 +6,48 @@ import { useAuth } from '../hooks/useAuth';
 
 const PACKAGES = [
   {
-    id: 'price_starter_10',
+    id: 'price_starter_50',
     name: 'Starter',
-    credits: 10,
-    price: 'R$ 9,90',
-    perCredit: 'R$ 0,99',
+    credits: 50,
+    price: 'R$ 19,90',
+    perCredit: 'R$ 0,40',
     color: '#22c55e',
     icon: '\u26A1',
     popular: false,
-        descricao: '10 análises de políticos',
+    descricao: '50 créditos — ideal para explorar a plataforma',
   },
   {
-    id: 'price_pro_50',
-    name: 'Pro',
-    credits: 50,
-    price: 'R$ 39,90',
-    perCredit: 'R$ 0,80',
+    id: 'price_pro_200',
+    name: 'Profissional',
+    credits: 200,
+    price: 'R$ 59,90',
+    perCredit: 'R$ 0,30',
     color: '#3b82f6',
     icon: '\uD83D\uDE80',
     popular: true,
-        descricao: '50 análises de políticos – melhor custo-benefício',
+    descricao: '200 créditos — melhor custo-benefício',
   },
   {
-    id: 'price_ultra_200',
-    name: 'Ultra',
-    credits: 200,
-    price: 'R$ 99,90',
-    perCredit: 'R$ 0,50',
+    id: 'price_analista_500',
+    name: 'Analista',
+    credits: 500,
+    price: 'R$ 129,90',
+    perCredit: 'R$ 0,26',
     color: '#8b5cf6',
     icon: '\uD83D\uDC8E',
     popular: false,
-        descricao: '200 análises de políticos para uso intensivo',
+    descricao: '500 créditos para uso intensivo e dossiês completos',
   },
   {
-    id: 'price_ilimitado',
-    name: 'Ilimitado',
+    id: 'price_enterprise',
+    name: 'Enterprise',
     credits: 999999,
-    price: 'R$ 199,90/mês',
+    price: 'R$ 299/mês',
     perCredit: 'Ilimitado',
     color: '#f59e0b',
     icon: '\u221E',
     popular: false,
-    descricao: 'Análises e chats ilimitados + acesso à barra de perguntas subjetivas à nossa IA',
+    descricao: 'Créditos ilimitados + API dedicada + suporte prioritário',
   },
 ];
 
@@ -255,10 +255,15 @@ export default function CreditosPage() {
       <div style={{ background: '#f8fafc', border: '1.5px solid #e2e8f0', borderRadius: 12, padding: 20, marginTop: 32 }}>
         <strong style={{ color: '#1e293b' }}>Como funcionam os créditos?</strong>
         <ul style={{ marginTop: 12, color: '#64748b', lineHeight: 2, paddingLeft: 20 }}>
-          <li>Chat com IA (apenas Ilimitado): <strong>1 crédito</strong> por mensagem</li>
-          <li>Análise completa de político: <strong>2 créditos</strong></li>
-          <li>Novos usuários recebem <strong>5 créditos grátis</strong></li>
-          <li>Plano Ilimitado inclui acesso à <strong>barra de perguntas subjetivas à nossa IA</strong></li>
+          <li>Ver ranking de deputados e score público: <strong>Gratuito</strong></li>
+          <li>Detalhes CEAP de um deputado: <strong>2 créditos</strong></li>
+          <li>Lista de emendas de um deputado: <strong>1 crédito</strong></li>
+          <li>Score detalhado com alertas: <strong>3 créditos</strong></li>
+          <li>Dossiê PDF básico: <strong>5 créditos</strong></li>
+          <li>Análise forense de funcionários: <strong>10 créditos</strong></li>
+          <li>Cruzamento CNPJ + CEIS + emendas: <strong>15 créditos</strong></li>
+          <li>Dossiê completo: <strong>20 créditos</strong></li>
+          <li>Novos usuários recebem <strong>10 créditos bônus</strong></li>
           <li>Pagamento seguro via Stripe (cartão)</li>
         </ul>
       </div>

--- a/frontend/src/pages/UsuarioPage.jsx
+++ b/frontend/src/pages/UsuarioPage.jsx
@@ -1,18 +1,48 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { Helmet } from "react-helmet-async";
+import { httpsCallable } from "firebase/functions";
+import { functions } from "../lib/firebase";
 import { useAuth } from "../hooks/useAuth";
+import { Coins, FileText, ShieldCheck, Settings, ChevronRight } from "lucide-react";
+
+const TIPO_LABELS = {
+  PURCHASE:         { label: "Compra",      color: "#22c55e", sign: "+" },
+  TRIAL:            { label: "Boas-vindas", color: "#3b82f6", sign: "+" },
+  CONSUME_CHAT:     { label: "Chat IA",     color: "#ef4444", sign: "" },
+  CONSUME_ANALYSIS: { label: "Análise",     color: "#ef4444", sign: "" },
+  BONUS:            { label: "Bônus",       color: "#8b5cf6", sign: "+" },
+  REFERRAL_BONUS:   { label: "Indicação",   color: "#8b5cf6", sign: "+" },
+  REFUND:           { label: "Estorno",     color: "#f59e0b", sign: "+" },
+  uso:              { label: "Uso",         color: "#ef4444", sign: "" },
+};
 
 /**
- * Área do usuário — saldo, atalhos (histórico detalhado em /perfil e /creditos).
+ * Área do usuário — saldo em destaque, histórico de consumo, atalhos.
  */
 export default function UsuarioPage() {
   const navigate = useNavigate();
-  const { user, credits, creditsComprado, creditsBonus, loading } = useAuth();
+  const { user, credits, creditsComprado, creditsBonus, loading: authLoading } = useAuth();
+  const [historico, setHistorico] = useState([]);
+  const [loadingHist, setLoadingHist] = useState(true);
 
   useEffect(() => {
-    if (!loading && !user) navigate("/login", { state: { from: "/usuario" } });
-  }, [user, loading, navigate]);
+    if (!authLoading && !user) navigate("/login", { state: { from: "/usuario" } });
+  }, [user, authLoading, navigate]);
+
+  useEffect(() => {
+    if (!user) return;
+    (async () => {
+      try {
+        const res = await httpsCallable(functions, "getCreditHistory")({ limit: 15 });
+        setHistorico(res.data?.historico || []);
+      } catch {
+        setHistorico([]);
+      } finally {
+        setLoadingHist(false);
+      }
+    })();
+  }, [user]);
 
   if (!user) {
     return (
@@ -31,82 +61,172 @@ export default function UsuarioPage() {
       <Helmet>
         <title>Minha conta | TransparenciaBR</title>
       </Helmet>
-      <div style={{ maxWidth: 560, margin: "0 auto" }}>
+      <div style={{ maxWidth: 640, margin: "0 auto" }}>
         <h1 style={{ fontSize: 26, fontWeight: 700, color: "#0f172a", marginBottom: 8 }}>Minha conta</h1>
         <p style={{ color: "#64748b", fontSize: 14, marginBottom: 28 }}>
           {user.displayName || user.email}
         </p>
 
+        {/* ── Saldo de créditos ────────────────────────────────── */}
         <div
           style={{
-            background: "#fff",
-            border: "1px solid #e2e8f0",
+            background: "linear-gradient(135deg,#01696f,#0e8c85)",
             borderRadius: 16,
             padding: 28,
             marginBottom: 20,
-            boxShadow: "0 4px 24px rgba(15,23,42,0.06)",
+            color: "#fff",
+            boxShadow: "0 4px 24px rgba(1,105,111,0.25)",
           }}
         >
-          <p style={{ fontSize: 12, fontWeight: 600, color: "#64748b", textTransform: "uppercase", letterSpacing: "0.06em", margin: "0 0 8px" }}>
-            Saldo de créditos
-          </p>
-          <p style={{ fontSize: 42, fontWeight: 800, color: "#01696f", margin: "0 0 12px", lineHeight: 1 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
+            <Coins size={20} />
+            <span style={{ fontSize: 12, fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.06em", opacity: 0.85 }}>
+              Saldo de créditos
+            </span>
+          </div>
+          <p style={{ fontSize: 48, fontWeight: 800, margin: "0 0 12px", lineHeight: 1 }}>
             {total.toLocaleString("pt-BR")}
           </p>
-          <p style={{ fontSize: 13, color: "#64748b", margin: 0 }}>
-            Comprados: <strong style={{ color: "#0f172a" }}>{comprado.toLocaleString("pt-BR")}</strong>
+          <p style={{ fontSize: 13, margin: 0, opacity: 0.8 }}>
+            Comprados: <strong>{comprado.toLocaleString("pt-BR")}</strong>
             {" · "}
-            Bônus: <strong style={{ color: "#0f172a" }}>{bonus.toLocaleString("pt-BR")}</strong>
+            Bônus: <strong>{bonus.toLocaleString("pt-BR")}</strong>
           </p>
         </div>
 
-        <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-          <Link
-            to="/creditos"
-            style={{
-              display: "block",
-              textAlign: "center",
-              padding: "14px 20px",
-              borderRadius: 12,
-              background: "#01696f",
-              color: "#fff",
-              fontWeight: 700,
-              textDecoration: "none",
-              fontSize: 15,
-            }}
-          >
-            Comprar créditos
-          </Link>
+        {/* ── Comprar créditos CTA ─────────────────────────────── */}
+        <Link
+          to="/creditos"
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            padding: "16px 20px",
+            borderRadius: 12,
+            background: "#fff",
+            border: "1.5px solid #e2e8f0",
+            color: "#0f172a",
+            fontWeight: 600,
+            textDecoration: "none",
+            fontSize: 15,
+            marginBottom: 10,
+          }}
+        >
+          <span style={{ display: "flex", alignItems: "center", gap: 10 }}>
+            <Coins size={18} color="#01696f" /> Comprar créditos
+          </span>
+          <ChevronRight size={18} color="#94a3b8" />
+        </Link>
+
+        {/* ── Atalhos ──────────────────────────────────────────── */}
+        <div style={{ display: "flex", gap: 10, marginBottom: 28 }}>
           <Link
             to="/perfil"
             style={{
-              display: "block",
-              textAlign: "center",
-              padding: "14px 20px",
+              flex: 1,
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              padding: "14px 16px",
               borderRadius: 12,
               background: "#fff",
+              border: "1.5px solid #e2e8f0",
               color: "#0f172a",
-              fontWeight: 600,
+              fontWeight: 500,
               textDecoration: "none",
-              fontSize: 14,
-              border: "1px solid #e2e8f0",
+              fontSize: 13,
             }}
           >
-            Meu cofre e histórico de dossiês
+            <FileText size={16} color="#64748b" /> Dossiês
+          </Link>
+          <Link
+            to="/ranking"
+            style={{
+              flex: 1,
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              padding: "14px 16px",
+              borderRadius: 12,
+              background: "#fff",
+              border: "1.5px solid #e2e8f0",
+              color: "#0f172a",
+              fontWeight: 500,
+              textDecoration: "none",
+              fontSize: 13,
+            }}
+          >
+            <ShieldCheck size={16} color="#64748b" /> Ranking
           </Link>
           <Link
             to="/dashboard"
             style={{
-              display: "block",
-              textAlign: "center",
-              padding: "12px 20px",
-              color: "#64748b",
-              fontSize: 14,
+              flex: 1,
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              padding: "14px 16px",
+              borderRadius: 12,
+              background: "#fff",
+              border: "1.5px solid #e2e8f0",
+              color: "#0f172a",
+              fontWeight: 500,
+              textDecoration: "none",
+              fontSize: 13,
             }}
           >
-            Painel
+            <Settings size={16} color="#64748b" /> Painel
           </Link>
         </div>
+
+        {/* ── Histórico de consumo ─────────────────────────────── */}
+        <h2 style={{ fontSize: 18, fontWeight: 700, color: "#0f172a", marginBottom: 12 }}>
+          Histórico de consumo
+        </h2>
+        {loadingHist ? (
+          <p style={{ color: "#94a3b8", fontSize: 14 }}>Carregando...</p>
+        ) : historico.length === 0 ? (
+          <div style={{ background: "#fff", border: "1.5px solid #e2e8f0", borderRadius: 12, padding: "32px 20px", textAlign: "center" }}>
+            <p style={{ color: "#94a3b8", fontSize: 14, margin: 0 }}>
+              Nenhuma transação registrada ainda.
+            </p>
+          </div>
+        ) : (
+          <div style={{ background: "#fff", border: "1.5px solid #e2e8f0", borderRadius: 12, overflow: "hidden" }}>
+            <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 14 }}>
+              <thead>
+                <tr style={{ background: "#f8fafc", borderBottom: "1px solid #e2e8f0" }}>
+                  <th style={{ padding: "10px 16px", textAlign: "left", color: "#64748b", fontWeight: 600 }}>Tipo</th>
+                  <th style={{ padding: "10px 16px", textAlign: "right", color: "#64748b", fontWeight: 600 }}>Créditos</th>
+                  <th style={{ padding: "10px 16px", textAlign: "right", color: "#64748b", fontWeight: 600 }}>Data</th>
+                </tr>
+              </thead>
+              <tbody>
+                {historico.map((h, i) => {
+                  const info = TIPO_LABELS[h.tipo] || { label: h.tipo || "—", color: "#6b7280", sign: "" };
+                  const val = h.credits ?? h.valor ?? 0;
+                  const data = (h.criadoEm?.seconds || h.ts?.seconds)
+                    ? new Date((h.criadoEm?.seconds || h.ts?.seconds) * 1000).toLocaleDateString("pt-BR")
+                    : "—";
+                  return (
+                    <tr key={i} style={{ borderBottom: "1px solid #f1f5f9" }}>
+                      <td style={{ padding: "10px 16px" }}>
+                        <span style={{ background: info.color + "22", color: info.color, borderRadius: 6, padding: "2px 10px", fontWeight: 600, fontSize: 12 }}>
+                          {info.label}
+                        </span>
+                        {h.descricao && <span style={{ color: "#94a3b8", fontSize: 12, marginLeft: 8 }}>{h.descricao}</span>}
+                      </td>
+                      <td style={{ padding: "10px 16px", textAlign: "right", fontWeight: 700, color: val > 0 ? "#22c55e" : "#ef4444" }}>
+                        {val > 0 ? "+" : ""}{val}
+                      </td>
+                      <td style={{ padding: "10px 16px", textAlign: "right", color: "#64748b" }}>{data}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Resumo

### Novos componentes reutilizáveis (Prioridade 3 do roteiro)
- **ScoreBadge** — badge colorido com score 0-100 (verde >60, amarelo 30-60, vermelho <30, azul >85)
- **AlertaForense** — card de alerta com severidade (red/yellow/green) usando ícones lucide
- **CreditBadge** — saldo de créditos para o header/navbar (clicável → /usuario)
- **EmptyState** — estado vazio com ícone, mensagem e CTA opcional

### Dependências
- `recharts@3.8.1` — gráficos (Recharts)
- `lucide-react@1.8.0` — ícones

### CreditosPage — pacotes conforme roteiro
- Starter: 50 créditos = R$ 19,90
- Profissional: 200 créditos = R$ 59,90
- Analista: 500 créditos = R$ 129,90
- Enterprise: ilimitado = R$ 299/mês
- Tabela de custos por ação atualizada (CEAP 2cr, emendas 1cr, dossiê 20cr, etc.)

### UsuarioPage (Prioridade 7)
- Saldo com destaque visual (gradiente teal)
- Histórico de consumo integrado (chama getCreditHistory)
- Atalhos: Dossiês, Ranking, Painel
- Ícones lucide em todos os elementos

### Build
`npm run build` passa sem erros.