### PR TITLE
feat: integrar componentes + Stripe v2 + fontes + rotas públicas

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,7 +16,7 @@
     <meta name="robots" content="index, follow" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,600;9..144,700;9..144,800&family=Inter:wght@300;400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -61,26 +61,26 @@ export default function App() {
             <Route path="/mapa" element={<MapaPage />} />
             <Route path="/saude" element={<HealthMap />} />
             <Route path="/metodologia" element={<MetodologiaPage />} />
+
+            {/* Rotas públicas — conteúdo premium protegido por CreditGate dentro da página */}
+            <Route path="/politico/:colecao/:id" element={<PoliticoPage user={user} />} />
+            <Route path="/deputado/:nome" element={<PoliticoPage user={user} />} />
+            <Route path="/emenda/:id" element={<EmendaPage />} />
+            <Route path="/emendas" element={<BancoEmendasPage />} />
+            <Route path="/dossie/:id" element={<DossiePage />} />
+
+            {/* Rotas autenticadas */}
             {user ? (
               <>
                 <Route path="/dashboard" element={<DashboardPage user={user} />} />
                 <Route path="/creditos" element={<CreditosPage user={user} />} />
                 <Route path="/perfil" element={<PerfilPage />} />
                 <Route path="/usuario" element={<UsuarioPage />} />
-                <Route path="/politico/:colecao/:id" element={<PoliticoPage user={user} />} />
-                <Route path="/deputado/:nome" element={<PoliticoPage user={user} />} />
-                <Route path="/emenda/:id" element={<EmendaPage />} />
-                <Route path="/emendas" element={<BancoEmendasPage />} />
                 <Route path="/comparador" element={<ComparadorPage />} />
-                <Route path="/dossie/:id" element={<DossiePage />} />
                 {isAdmin && <Route path="/admin" element={<AdminDashboard />} />}
-                <Route path="*" element={<NotFoundPage />} />
               </>
-            ) : (
-              <>
-                <Route path="*" element={<NotFoundPage />} />
-              </>
-            )}
+            ) : null}
+            <Route path="*" element={<NotFoundPage />} />
           </Routes>
         </Suspense>
         </Layout>

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import CreditWallet from "./CreditWallet";
+import CreditBadge from "./CreditBadge";
 import GlobalSearch from "./GlobalSearch";
 import { AuditSealCompact } from "./AuditSeal";
 
@@ -62,7 +62,7 @@ export default function Navbar({ user, logout, credits, isAdmin }) {
         <Link to="/alertas" style={navLink}>Alertas</Link>
         <Link to="/mapa"    style={navLink}>Mapa</Link>
         <Link to="/metodologia" style={navLink}>Metodologia</Link>
-        {user && <Link to="/emendas" style={navLink}>Emendas</Link>}
+        <Link to="/emendas" style={navLink}>Emendas</Link>
         {user && <Link to="/comparador" style={navLink}>Comparar</Link>}
       </div>
 
@@ -83,7 +83,7 @@ export default function Navbar({ user, logout, credits, isAdmin }) {
               }
               <span style={{ fontSize: 13, fontWeight: 500, color: '#2D2D2D' }}>{firstName}</span>
               <AuditSealCompact />
-              <CreditWallet credits={credits} compact />
+              <CreditBadge credits={credits} compact />
             </button>
             {dropdownOpen && (
               <div style={{ position: 'absolute', right: 0, top: 'calc(100% + 8px)', background: '#fff', borderRadius: 12, boxShadow: '0 8px 30px rgba(0,0,0,0.12)', minWidth: 210, border: '1px solid #EDEBE8', zIndex: 200, overflow: 'hidden' }}>

--- a/frontend/src/pages/PoliticoPage.jsx
+++ b/frontend/src/pages/PoliticoPage.jsx
@@ -15,6 +15,8 @@ import NepotismoCard from "../components/NepotismoCard";
 import VerbaGabineteSection from "../components/VerbaGabineteSection";
 import EncaminhamentoEmendas from "../components/EncaminhamentoEmendas";
 import { CreditGate } from "../components/CreditGate";
+import ScoreBadge from "../components/ScoreBadge";
+import AlertaForense from "../components/AlertaForense";
 import { parseCamaraValorReais } from "../utils/moneyCamara";
 import {
   loadRankingOrgExternoMap,
@@ -383,7 +385,9 @@ export default function PoliticoPage() {
               </>
             )}
             {pol.score != null && (
-              <> · Índice TransparenciaBR (plataforma): <strong>{parseFloat(pol.score).toFixed(1)}</strong></>
+              <span style={{ display: "inline-flex", alignItems: "center", gap: 8, marginLeft: 4 }}>
+                · Índice TransparenciaBR: <ScoreBadge score={parseFloat(pol.score)} size="sm" />
+              </span>
             )}
           </div>
         </div>

--- a/frontend/src/pages/RankingPage.jsx
+++ b/frontend/src/pages/RankingPage.jsx
@@ -26,6 +26,7 @@ import {
   getRiskColorDark,
   getRiskLabel,
 } from "../utils/colorUtils";
+import ScoreBadge from "../components/ScoreBadge";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 function fmtBRL(val) {
@@ -136,11 +137,8 @@ function DeputadoRow({ dep, total }) {
         </div>
 
         {/* Score plataforma (BigQuery) */}
-        <div className="text-right shrink-0 min-w-[52px] hidden md:block">
-          <p className="text-[10px]" style={{ color: "#CCC" }}>TBR</p>
-          <p className="text-xs font-semibold tabular-nums" style={{ color: "#555" }}>
-            {dep.score_plataforma != null ? Number(dep.score_plataforma).toFixed(1) : "—"}
-          </p>
+        <div className="shrink-0 hidden md:block">
+          <ScoreBadge score={dep.score_plataforma} size="sm" />
         </div>
 
         {/* CEAP — oculto em mobile */}

--- a/functions/ENV_VARS.md
+++ b/functions/ENV_VARS.md
@@ -7,3 +7,34 @@
 Configure com `firebase functions:secrets:set PORTAL_TRANSPARENCIA_API_KEY` ou no Console do Firebase.
 
 Documentação: https://api.portaldatransparencia.gov.br/
+
+## Stripe (pagamentos)
+
+- **`STRIPE_SECRET_KEY`** — chave secreta (sk_live_... ou sk_test_...)
+- **`STRIPE_WEBHOOK_SECRET`** — segredo do webhook (whsec_...)
+
+### Preços por pacote (Stripe Price IDs)
+
+Criar os produtos/preços no [Stripe Dashboard](https://dashboard.stripe.com/products) e configurar:
+
+| Variável | Pacote | Valor | Créditos | Modo |
+|----------|--------|-------|----------|------|
+| `STRIPE_PRICE_STARTER_50` | Starter | R$ 19,90 | 50 | payment |
+| `STRIPE_PRICE_PRO_200` | Profissional | R$ 59,90 | 200 | payment |
+| `STRIPE_PRICE_ANALISTA_500` | Analista | R$ 129,90 | 500 | payment |
+| `STRIPE_PRICE_ENTERPRISE` | Enterprise | R$ 299/mês | Ilimitado | subscription |
+
+```bash
+firebase functions:secrets:set STRIPE_SECRET_KEY
+firebase functions:secrets:set STRIPE_WEBHOOK_SECRET
+firebase functions:secrets:set STRIPE_PRICE_STARTER_50
+firebase functions:secrets:set STRIPE_PRICE_PRO_200
+firebase functions:secrets:set STRIPE_PRICE_ANALISTA_500
+firebase functions:secrets:set STRIPE_PRICE_ENTERPRISE
+```
+
+### Pacotes legados (se ainda em uso)
+| `STRIPE_PRICE_STARTER_10` | Starter antigo | R$ 9,90 | 10 | payment |
+| `STRIPE_PRICE_PRO_50` | Pro antigo | R$ 39,90 | 50 | payment |
+| `STRIPE_PRICE_ULTRA_200` | Ultra antigo | R$ 99,90 | 200 | payment |
+| `STRIPE_PRICE_ILIMITADO` | Ilimitado antigo | R$ 199,90/mês | ∞ | subscription |

--- a/functions/index.js
+++ b/functions/index.js
@@ -209,9 +209,14 @@ const APP_PUBLIC_ORIGIN =
   process.env.APP_PUBLIC_ORIGIN || 'https://fiscallizapa.web.app';
 
 const PACKAGE_CREDITS = {
+  // Pacotes novos (roteiro v2)
+  price_starter_50: 50,
+  price_pro_200: 200,
+  price_analista_500: 500,
+  // Pacotes legados (backward compat)
   price_starter_10: 10,
   price_pro_50: 50,
-  price_ultra_200: 200
+  price_ultra_200: 200,
 };
 
 // ─────────────────────────────────────────────
@@ -270,16 +275,22 @@ exports.buyCredits = onCall(OPTS, async (req) => {
   if (!packageId) throw new HttpsError('invalid-argument', 'packageId obrigatório.');
 
   const priceEnvMap = {
-    price_starter_10: process.env.STRIPE_PRICE_STARTER_10,
-    price_pro_50: process.env.STRIPE_PRICE_PRO_50,
-    price_ultra_200: process.env.STRIPE_PRICE_ULTRA_200,
-    price_ilimitado: process.env.STRIPE_PRICE_ILIMITADO
+    // Pacotes novos (roteiro v2)
+    price_starter_50:    process.env.STRIPE_PRICE_STARTER_50,
+    price_pro_200:       process.env.STRIPE_PRICE_PRO_200,
+    price_analista_500:  process.env.STRIPE_PRICE_ANALISTA_500,
+    price_enterprise:    process.env.STRIPE_PRICE_ENTERPRISE,
+    // Pacotes legados (backward compat)
+    price_starter_10:    process.env.STRIPE_PRICE_STARTER_10,
+    price_pro_50:        process.env.STRIPE_PRICE_PRO_50,
+    price_ultra_200:     process.env.STRIPE_PRICE_ULTRA_200,
+    price_ilimitado:     process.env.STRIPE_PRICE_ILIMITADO,
   };
   const priceId = priceEnvMap[packageId];
   if (!priceId) {
     throw new HttpsError(
       'failed-precondition',
-      'Stripe não configurado: defina STRIPE_PRICE_STARTER_10, STRIPE_PRICE_PRO_50, STRIPE_PRICE_ULTRA_200 e/ou STRIPE_PRICE_ILIMITADO nas variáveis de ambiente das Functions.'
+      `Stripe n\u00e3o configurado para pacote "${packageId}". Defina a vari\u00e1vel STRIPE_PRICE_* correspondente nas Functions.`
     );
   }
 
@@ -309,7 +320,7 @@ exports.buyCredits = onCall(OPTS, async (req) => {
     }
   })(origin);
 
-  const mode = packageId === 'price_ilimitado' ? 'subscription' : 'payment';
+  const mode = (packageId === 'price_ilimitado' || packageId === 'price_enterprise') ? 'subscription' : 'payment';
   const session = await stripe.checkout.sessions.create({
     mode,
     payment_method_types: ['card'],
@@ -412,7 +423,7 @@ exports.stripeWebhook = onRequest(
         const pkg = session.metadata?.packageId || '';
 
         if (session.mode === 'subscription') {
-          const plano = pkg === 'price_ilimitado' ? 'ilimitado' : 'premium';
+          const plano = (pkg === 'price_ilimitado' || pkg === 'price_enterprise') ? 'ilimitado' : 'premium';
           await ref.set(
             {
               plano,


### PR DESCRIPTION
## Alterações

### Frontend
- **Navbar**: CreditBadge (lucide-react) substituiu CreditWallet; link Emendas visível para todos
- **App.jsx**: rotas /politico, /deputado, /emendas, /emenda, /dossie agora públicas (CreditGate protege premium)
- **RankingPage**: ScoreBadge na coluna TBR (verde/amarelo/vermelho/azul)
- **PoliticoPage**: ScoreBadge ao lado do Índice TransparenciaBR; AlertaForense importado
- **index.html**: fonte Fraunces (display/serif) via Google Fonts

### Backend (Stripe)
- Novos pacotes: Starter 50cr, Pro 200cr, Analista 500cr, Enterprise (subscription)
- Backward compat: pacotes antigos mantidos
- Webhook: `price_enterprise` → plano ilimitado
- ENV_VARS.md: documentação de todas as variáveis Stripe

### Ação pós-deploy
1. Criar 4 produtos no [Stripe Dashboard](https://dashboard.stripe.com/products):
   - Starter R$19,90 (50 créditos)
   - Profissional R$59,90 (200 créditos)  
   - Analista R$129,90 (500 créditos)
   - Enterprise R$299/mês (subscription)
2. Copiar os Price IDs e configurar:
   ```
   firebase functions:secrets:set STRIPE_PRICE_STARTER_50
   firebase functions:secrets:set STRIPE_PRICE_PRO_200
   firebase functions:secrets:set STRIPE_PRICE_ANALISTA_500
   firebase functions:secrets:set STRIPE_PRICE_ENTERPRISE
   ```