### PR TITLE
Hotpage: credit bypass, CreditGate teaser, emendas by codigoAutor, logo SVG fix

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -51,6 +51,7 @@ service cloud.firestore {
     function touchesCriticalFields() {
       return fieldsDiff().hasAny([
         'creditos', 'creditos_bonus', 'isAdmin', 'role', 'uid', 'criadoEm',
+        'creditos_ilimitados',
         'dossies_gratuitos_restantes'   // cota → só decrementar via função específica
       ]);
     }

--- a/frontend/src/components/CreditGate.jsx
+++ b/frontend/src/components/CreditGate.jsx
@@ -1,17 +1,27 @@
-import { useState } from "react";
+import { useState, Children } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { useCreditSystem } from "../hooks/useCreditSystem";
 import { useAuth } from "../hooks/useAuth";
 import ModalCompraCreditos from "./ModalCompraCreditos";
 
+const PREVIEW_COUNT = 3;
+
+function wrapChild(node, key) {
+  return (
+    <div key={key} style={{ marginBottom: 8 }}>
+      {node}
+    </div>
+  );
+}
+
 /**
- * Conteúdo premium: blur até o usuário desbloquear consumindo créditos.
+ * Conteúdo premium: primeiras linhas legíveis; restante com blur até desbloquear.
  */
 export function CreditGate({ custo, descricao, children, onDesbloqueado }) {
   const navigate = useNavigate();
   const location = useLocation();
   const { user } = useAuth();
-  const { checkCredits, consumirCreditos } = useCreditSystem();
+  const { checkCredits, consumirCreditos, saldoExibicao, isAdmin } = useCreditSystem();
   const [desbloqueado, setDesbloqueado] = useState(false);
   const [loading, setLoading] = useState(false);
   const [showModal, setShowModal] = useState(false);
@@ -36,65 +46,127 @@ export function CreditGate({ custo, descricao, children, onDesbloqueado }) {
       setDesbloqueado(true);
       onDesbloqueado?.();
     } catch (e) {
-      setErro(e?.message || "Não foi possível desbloquear.");
+      const msg = e?.message || "Não foi possível desbloquear.";
+      if (msg.includes("boas-vindas") || msg.includes("Bem-vindo")) {
+        setErro("🎉 " + msg);
+      } else {
+        setErro(msg);
+      }
     } finally {
       setLoading(false);
     }
   };
 
-  if (desbloqueado) return children;
+  if (desbloqueado || isAdmin) return children;
+
+  const childArray = Children.toArray(children);
+  const visible = childArray.slice(0, PREVIEW_COUNT);
+  const blurred = childArray.slice(PREVIEW_COUNT);
+  const hasBlur = blurred.length > 0;
 
   return (
     <>
-      <div style={{ position: "relative", borderRadius: 12, overflow: "hidden" }}>
-        <div
-          style={{
-            filter: "blur(6px)",
-            pointerEvents: "none",
-            userSelect: "none",
-            opacity: 0.85,
-          }}
-        >
-          {children}
-        </div>
-        <div
-          style={{
-            position: "absolute",
-            inset: 0,
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            justifyContent: "center",
-            background: "rgba(15, 23, 42, 0.28)",
-            padding: 16,
-            gap: 10,
-          }}
-        >
-          <button
-            type="button"
-            onClick={tentar}
-            disabled={loading}
+      <div className="credit-gate-wrapper" style={{ position: "relative", borderRadius: 12, overflow: "hidden" }}>
+        {visible.map((c, i) => wrapChild(c, `cg-v-${i}`))}
+
+        {hasBlur ? (
+          <div style={{ position: "relative", marginTop: 8 }}>
+            <div
+              style={{
+                filter: "blur(6px)",
+                pointerEvents: "none",
+                userSelect: "none",
+                maxHeight: 220,
+                overflow: "hidden",
+              }}
+            >
+              {blurred.map((c, i) => wrapChild(c, `cg-b-${i}`))}
+            </div>
+            <div
+              style={{
+                position: "absolute",
+                inset: 0,
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                justifyContent: "center",
+                background: "rgba(15, 23, 42, 0.28)",
+                padding: 16,
+                gap: 10,
+              }}
+            >
+              <button
+                type="button"
+                onClick={tentar}
+                disabled={loading}
+                className="btn-unlock"
+                style={{
+                  background: "#1B5E3B",
+                  color: "#fff",
+                  padding: "12px 22px",
+                  borderRadius: 10,
+                  fontWeight: 700,
+                  fontSize: 14,
+                  border: "none",
+                  cursor: loading ? "wait" : "pointer",
+                  fontFamily: "'Inter', sans-serif",
+                  minHeight: 44,
+                }}
+              >
+                {loading ? "…" : `🔓 Ver tudo · ${custo} crédito(s)`}
+              </button>
+              {saldoExibicao != null && (
+                <p className="credit-balance" style={{ margin: 0, fontSize: 12, color: "#e2e8f0" }}>
+                  Saldo: {saldoExibicao} crédito(s)
+                </p>
+              )}
+              {erro ? (
+                <p style={{ margin: 0, fontSize: 12, color: "#fecaca", textAlign: "center", maxWidth: 280 }}>
+                  {erro}
+                </p>
+              ) : null}
+            </div>
+          </div>
+        ) : (
+          <div
             style={{
-              background: "#01696f",
-              color: "#fff",
-              padding: "12px 22px",
+              marginTop: 12,
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "center",
+              gap: 10,
+              padding: 16,
+              background: "rgba(248,250,252,0.95)",
               borderRadius: 10,
-              fontWeight: 700,
-              fontSize: 14,
-              border: "none",
-              cursor: loading ? "wait" : "pointer",
-              boxShadow: "0 4px 14px rgba(1,105,111,0.35)",
-              fontFamily: "'Inter', sans-serif",
+              border: "1px solid #e5e7eb",
             }}
           >
-            {loading ? "…" : `Desbloquear · ${custo} crédito(s)`}
-          </button>
-          {erro ? (
-            <p style={{ margin: 0, fontSize: 12, color: "#fecaca", textAlign: "center", maxWidth: 280 }}>
-              {erro}
-            </p>
-          ) : null}
-        </div>
+            <button
+              type="button"
+              onClick={tentar}
+              disabled={loading}
+              style={{
+                background: "#1B5E3B",
+                color: "#fff",
+                padding: "12px 22px",
+                borderRadius: 10,
+                fontWeight: 700,
+                fontSize: 14,
+                border: "none",
+                cursor: loading ? "wait" : "pointer",
+                minHeight: 44,
+              }}
+            >
+              {loading ? "…" : `Desbloquear · ${custo} crédito(s)`}
+            </button>
+            {saldoExibicao != null && (
+              <p style={{ margin: 0, fontSize: 12, color: "#64748b" }}>Saldo: {saldoExibicao} crédito(s)</p>
+            )}
+            {erro ? (
+              <p style={{ margin: 0, fontSize: 12, color: "#b91c1c", textAlign: "center", maxWidth: 280 }}>{erro}</p>
+            ) : null}
+          </div>
+        )}
       </div>
       {showModal ? <ModalCompraCreditos onClose={() => setShowModal(false)} /> : null}
     </>

--- a/frontend/src/components/LogoOrb.jsx
+++ b/frontend/src/components/LogoOrb.jsx
@@ -1,0 +1,33 @@
+import { useId } from "react";
+
+/** Marca orbe — gradientes com IDs únicos por instância (evita colisão SVG na página). */
+export default function LogoOrb({ size = 32 }) {
+  const uid = useId().replace(/:/g, "");
+  const ga = `orbA-${uid}`;
+  const gb = `orbB-${uid}`;
+  const gc = `orbC-${uid}`;
+  return (
+    <svg width={size} height={size} viewBox="0 0 100 100" fill="none" aria-hidden>
+      <defs>
+        <linearGradient id={ga} x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" stopColor="#FBD87F" />
+          <stop offset="35%" stopColor="#F7B98B" />
+          <stop offset="65%" stopColor="#A8D8B0" />
+          <stop offset="100%" stopColor="#9ECFE8" />
+        </linearGradient>
+        <linearGradient id={gb} x1="100%" y1="0%" x2="0%" y2="100%">
+          <stop offset="0%" stopColor="#FBD87F" stopOpacity="0.7" />
+          <stop offset="50%" stopColor="#F7B98B" stopOpacity="0.5" />
+          <stop offset="100%" stopColor="#9ECFE8" stopOpacity="0.7" />
+        </linearGradient>
+        <linearGradient id={gc} x1="0%" y1="100%" x2="100%" y2="0%">
+          <stop offset="0%" stopColor="#A8D8B0" stopOpacity="0.6" />
+          <stop offset="100%" stopColor="#F7B98B" stopOpacity="0.4" />
+        </linearGradient>
+      </defs>
+      <path d="M50 8 A42 42 0 1 1 49.9 8" stroke={`url(#${ga})`} strokeWidth="14" fill="none" strokeLinecap="round" />
+      <path d="M50 16 A34 34 0 1 0 49.9 16" stroke={`url(#${gb})`} strokeWidth="10" fill="none" strokeLinecap="round" />
+      <path d="M50 26 A24 24 0 1 1 49.9 26" stroke={`url(#${gc})`} strokeWidth="7" fill="none" strokeLinecap="round" />
+    </svg>
+  );
+}

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -3,31 +3,7 @@ import { Link, useNavigate } from "react-router-dom";
 import CreditBadge from "./CreditBadge";
 import GlobalSearch from "./GlobalSearch";
 import { AuditSealCompact } from "./AuditSeal";
-
-const LogoOrb = ({ size = 32 }) => (
-  <svg width={size} height={size} viewBox="0 0 100 100" fill="none">
-    <defs>
-      <linearGradient id="orbA" x1="0%" y1="0%" x2="100%" y2="100%">
-        <stop offset="0%" stopColor="#FBD87F" />
-        <stop offset="35%" stopColor="#F7B98B" />
-        <stop offset="65%" stopColor="#A8D8B0" />
-        <stop offset="100%" stopColor="#9ECFE8" />
-      </linearGradient>
-      <linearGradient id="orbB" x1="100%" y1="0%" x2="0%" y2="100%">
-        <stop offset="0%" stopColor="#FBD87F" stopOpacity="0.7" />
-        <stop offset="50%" stopColor="#F7B98B" stopOpacity="0.5" />
-        <stop offset="100%" stopColor="#9ECFE8" stopOpacity="0.7" />
-      </linearGradient>
-      <linearGradient id="orbC" x1="0%" y1="100%" x2="100%" y2="0%">
-        <stop offset="0%" stopColor="#A8D8B0" stopOpacity="0.6" />
-        <stop offset="100%" stopColor="#F7B98B" stopOpacity="0.4" />
-      </linearGradient>
-    </defs>
-    <path d="M50 8 A42 42 0 1 1 49.9 8" stroke="url(#orbA)" strokeWidth="14" fill="none" strokeLinecap="round" />
-    <path d="M50 16 A34 34 0 1 0 49.9 16" stroke="url(#orbB)" strokeWidth="10" fill="none" strokeLinecap="round" />
-    <path d="M50 26 A24 24 0 1 1 49.9 26" stroke="url(#orbC)" strokeWidth="7" fill="none" strokeLinecap="round" />
-  </svg>
-);
+import LogoOrb from "./LogoOrb";
 
 export default function Navbar({ user, logout, credits, isAdmin }) {
   const [dropdownOpen, setDropdownOpen] = useState(false);

--- a/frontend/src/components/PresencaSection.jsx
+++ b/frontend/src/components/PresencaSection.jsx
@@ -139,7 +139,11 @@ function StatCard({ value, label, color, href }) {
 
 export default function PresencaSection({ politico, colecao, politicoId }) {
   const pol = politico || {};
-  const id = politicoId || pol.id || '';
+  const idDoc = politicoId || pol.id || '';
+  const idCamara =
+    pol.idCamara != null && String(pol.idCamara).trim() !== ''
+      ? String(pol.idCamara)
+      : idDoc;
 
   const overallPct = toNum(
     pol.presencaPct ?? pol.presenca ?? pol.presenca_geral_pct
@@ -170,11 +174,11 @@ export default function PresencaSection({ politico, colecao, politicoId }) {
     sessoesTotal > 0;
 
   const year = new Date().getFullYear();
-  const camaraBase = `https://www.camara.leg.br/deputados/${id}`;
-  const linkSessoes = id ? `${camaraBase}/presenca-plenario/${year}` : null;
-  const linkEventos = id ? `${camaraBase}/agenda` : null;
-  const linkProposicoes = id
-    ? `https://www.camara.leg.br/busca-portal?contextoBusca=BuscaProposicoes&pagina=1&order=data&abaEspecifica=true&q=autores.ideCadastro:%20${id}`
+  const camaraBase = `https://www.camara.leg.br/deputados/${idCamara}`;
+  const linkSessoes = idCamara ? `${camaraBase}/presenca-plenario/${year}` : null;
+  const linkEventos = idCamara ? `${camaraBase}/agenda` : null;
+  const linkProposicoes = idCamara
+    ? `https://www.camara.leg.br/busca-portal?contextoBusca=BuscaProposicoes&pagina=1&order=data&abaEspecifica=true&q=autores.ideCadastro:%20${idCamara}`
     : null;
 
   const sectionStyle = {
@@ -221,7 +225,7 @@ export default function PresencaSection({ politico, colecao, politicoId }) {
       </h3>
 
       <p style={{ marginTop: 0, marginBottom: 18, color: 'var(--text-secondary)' }}>
-        Dados consolidados de presença em plenário, comissões e atividade legislativa.
+        Dados consolidados de presença em plenário, comissões e atividade legislativa (mandato atual — legislatura 57, 2023–2026).
       </p>
 
       {classificacao && (

--- a/frontend/src/components/ProjetosSection.jsx
+++ b/frontend/src/components/ProjetosSection.jsx
@@ -1,8 +1,42 @@
 import { useState, useEffect } from "react";
 
-export default function ProjetosSection({ deputadoId, colecao }) {
+const LEGISLATURA_ATUAL = 57;
+
+async function fetchTodasProposicoesAutor(idCamara) {
+  const all = [];
+  for (let pagina = 1; pagina <= 20; pagina++) {
+    const url =
+      `https://dadosabertos.camara.leg.br/api/v2/proposicoes` +
+      `?idDeputadoAutor=${encodeURIComponent(idCamara)}` +
+      `&idLegislatura=${LEGISLATURA_ATUAL}` +
+      `&ordem=DESC&ordenarPor=dataApresentacao&itens=100&pagina=${pagina}`;
+    const res = await fetch(url, { headers: { accept: "application/json" } });
+    if (!res.ok) break;
+    const data = await res.json();
+    const lista = Array.isArray(data?.dados) ? data.dados : [];
+    if (lista.length === 0) break;
+    all.push(...lista);
+    if (lista.length < 100) break;
+  }
+  return all;
+}
+
+function primeiroAutorId(prop) {
+  const id = prop?.autores?.[0]?.id;
+  if (id != null) return Number(id);
+  const uri = prop?.uri;
+  if (uri && typeof uri === "string") {
+    const m = uri.match(/\/deputados\/(\d+)/);
+    if (m) return Number(m[1]);
+  }
+  return null;
+}
+
+export default function ProjetosSection({ deputadoId, idCamara, colecao }) {
   const [projetos, setProjetos] = useState([]);
   const [loading, setLoading] = useState(true);
+
+  const idC = idCamara != null && String(idCamara).trim() !== "" ? Number(idCamara) : null;
 
   useEffect(() => {
     if (!deputadoId || colecao !== "deputados_federais") {
@@ -13,27 +47,24 @@ export default function ProjetosSection({ deputadoId, colecao }) {
 
     async function load() {
       setLoading(true);
-
       try {
-        const url =
-          `https://dadosabertos.camara.leg.br/api/v2/proposicoes` +
-          `?idDeputadoAutor=${deputadoId}&ordem=DESC&ordenarPor=dataApresentacao&itens=100`;
-
-        const res = await fetch(url, {
-          headers: { accept: "application/json" }
+        if (!Number.isFinite(idC)) {
+          setProjetos([]);
+          setLoading(false);
+          return;
+        }
+        const lista = await fetchTodasProposicoesAutor(idC);
+        const filtradas = lista.filter((p) => {
+          const aid = primeiroAutorId(p);
+          return aid === idC;
         });
-
-        const data = await res.json();
-        const lista = Array.isArray(data?.dados) ? data.dados : [];
-
-        const ordenada = lista
+        const ordenada = filtradas
           .filter((p) => p && (p.id || p.numero || p.ano))
           .sort((a, b) => {
             const da = new Date(a.dataApresentacao || a.dataHora || 0).getTime();
             const db = new Date(b.dataApresentacao || b.dataHora || 0).getTime();
             return db - da;
           });
-
         setProjetos(ordenada);
       } catch (err) {
         console.error("Erro ao buscar proposicoes:", err);
@@ -44,18 +75,27 @@ export default function ProjetosSection({ deputadoId, colecao }) {
     }
 
     load();
-  }, [deputadoId, colecao]);
+  }, [deputadoId, colecao, idC]);
 
   if (loading) {
     return (
+      <div style={{ padding: "40px", textAlign: "center", color: "var(--text-muted)" }}>
+        Carregando proposições...
+      </div>
+    );
+  }
+
+  if (!Number.isFinite(idC)) {
+    return (
       <div
         style={{
-          padding: "40px",
-          textAlign: "center",
-          color: "var(--text-muted)"
+          background: "var(--bg-secondary)",
+          borderRadius: "var(--radius-md)",
+          padding: "24px",
+          color: "var(--text-muted)",
         }}
       >
-        Carregando proposições...
+        ID numérico da Câmara indisponível — não foi possível listar proposições como autor principal.
       </div>
     );
   }
@@ -68,10 +108,10 @@ export default function ProjetosSection({ deputadoId, colecao }) {
           borderRadius: "var(--radius-md)",
           padding: "40px",
           textAlign: "center",
-          color: "var(--text-muted)"
+          color: "var(--text-muted)",
         }}
       >
-        Nenhuma proposição encontrada para este político.
+        Nenhuma proposição como autor principal encontrada (legislatura {LEGISLATURA_ATUAL}).
       </div>
     );
   }
@@ -83,7 +123,7 @@ export default function ProjetosSection({ deputadoId, colecao }) {
     PDL: "#2196f3",
     REQ: "#9e9e9e",
     PRC: "#8e24aa",
-    MPV: "#00897b"
+    MPV: "#00897b",
   };
 
   return (
@@ -92,36 +132,21 @@ export default function ProjetosSection({ deputadoId, colecao }) {
         background: "var(--bg-card)",
         borderRadius: "var(--radius-md)",
         padding: "24px",
-        border: "1px solid var(--border-light)"
+        border: "1px solid var(--border-light)",
       }}
     >
-      <h3
-        style={{
-          fontSize: "18px",
-          fontWeight: 700,
-          color: "var(--text-primary)",
-          marginBottom: "8px"
-        }}
-      >
-        Proposições Legislativas
+      <h3 style={{ fontSize: "18px", fontWeight: 700, color: "var(--text-primary)", marginBottom: "8px" }}>
+        Proposições (autor principal)
       </h3>
 
-      <p
-        style={{
-          fontSize: "13px",
-          color: "var(--text-muted)",
-          marginBottom: "16px"
-        }}
-      >
-        {projetos.length} proposições encontradas
+      <p style={{ fontSize: "13px", color: "var(--text-muted)", marginBottom: "16px" }}>
+        {projetos.length} proposições · legislatura {LEGISLATURA_ATUAL} · apenas primeiro autor na API da Câmara
       </p>
 
       <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
         {projetos.slice(0, 30).map((p) => {
           const cor = tipoColors[p.siglaTipo] || "#666";
-          const href = p.id
-            ? `https://www.camara.leg.br/propostas-legislativas/${p.id}`
-            : "#";
+          const href = p.id ? `https://www.camara.leg.br/propostas-legislativas/${p.id}` : "#";
 
           return (
             <a
@@ -138,19 +163,12 @@ export default function ProjetosSection({ deputadoId, colecao }) {
                 borderRadius: "var(--radius-sm)",
                 border: "1px solid var(--border-light)",
                 textDecoration: "none",
-                color: "inherit"
+                color: "inherit",
+                minHeight: 44,
               }}
             >
               <div style={{ flex: 1, minWidth: 0 }}>
-                <div
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: "8px",
-                    marginBottom: "4px",
-                    flexWrap: "wrap"
-                  }}
-                >
+                <div style={{ display: "flex", alignItems: "center", gap: "8px", marginBottom: "4px", flexWrap: "wrap" }}>
                   <span
                     style={{
                       padding: "2px 8px",
@@ -158,19 +176,14 @@ export default function ProjetosSection({ deputadoId, colecao }) {
                       fontSize: "11px",
                       fontWeight: 700,
                       background: `${cor}20`,
-                      color: cor
+                      color: cor,
                     }}
                   >
                     {p.siglaTipo || "PROP"} {p.numero || "s/n"}/{p.ano || ""}
                   </span>
 
                   {p.dataApresentacao ? (
-                    <span
-                      style={{
-                        fontSize: 12,
-                        color: "var(--text-muted)"
-                      }}
-                    >
+                    <span style={{ fontSize: 12, color: "var(--text-muted)" }}>
                       {new Date(p.dataApresentacao).toLocaleDateString("pt-BR")}
                     </span>
                   ) : null}
@@ -183,7 +196,7 @@ export default function ProjetosSection({ deputadoId, colecao }) {
                     lineHeight: 1.4,
                     overflow: "hidden",
                     textOverflow: "ellipsis",
-                    whiteSpace: "nowrap"
+                    whiteSpace: "nowrap",
                   }}
                   title={p.ementa || "Sem ementa"}
                 >
@@ -191,15 +204,7 @@ export default function ProjetosSection({ deputadoId, colecao }) {
                 </p>
               </div>
 
-              <span
-                style={{
-                  fontSize: "20px",
-                  marginLeft: "12px",
-                  color: "var(--text-muted)"
-                }}
-              >
-                ›
-              </span>
+              <span style={{ fontSize: "20px", marginLeft: "12px", color: "var(--text-muted)" }}>›</span>
             </a>
           );
         })}

--- a/frontend/src/components/VerbaGabineteSection.jsx
+++ b/frontend/src/components/VerbaGabineteSection.jsx
@@ -110,8 +110,11 @@ export default function VerbaGabineteSection({ colecao, politicoId, idCamara }) 
         <div>
           {pessoal.length === 0 ? (
             <>
-              <p style={{ color: 'var(--text-muted)' }}>Dados de pessoal de gabinete nao encontrados no banco local.</p>
-              <a href={`https://www.camara.leg.br/deputados/${idCamara}/pessoal-gabinete`} target="_blank" rel="noopener noreferrer" style={{ color: 'var(--accent-green)' }}>Consultar no Portal da Camara</a>
+              <p style={{ color: 'var(--text-muted)', marginBottom: 10, lineHeight: 1.5 }}>
+                Dados de pessoal do gabinete não estão neste painel. A API pública da Câmara não expõe a folha completa de assessores; consulte o Portal da Transparência (SIAPE) ou o site oficial do deputado.
+              </p>
+              <a href="https://portaldatransparencia.gov.br" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--accent-green)', display: 'inline-flex', alignItems: 'center', minHeight: 44, marginRight: 12 }}>Portal da Transparência ↗</a>
+              <a href={`https://www.camara.leg.br/deputados/${idCamara}/pessoal-gabinete`} target="_blank" rel="noopener noreferrer" style={{ color: 'var(--accent-green)', display: 'inline-flex', alignItems: 'center', minHeight: 44 }}>Página da Câmara ↗</a>
             </>
           ) : (
             pessoal.map((p, i) => (

--- a/frontend/src/hooks/useAuth.js
+++ b/frontend/src/hooks/useAuth.js
@@ -173,7 +173,7 @@ export function useAuth() {
           setCreditsComprado(comprado);
           setCreditsBonus(bonus);
           localStorage.setItem("userCredits", String(total));
-          setIsAdmin(data?.isAdmin === true);
+          setIsAdmin(data?.isAdmin === true || data?.role === "admin");
           setDailyQuota(data?.dossies_gratuitos_restantes ?? 0);
         } else {
           setIsAdmin(false);

--- a/frontend/src/hooks/useCreditSystem.js
+++ b/frontend/src/hooks/useCreditSystem.js
@@ -1,30 +1,50 @@
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
+import { doc, getDoc } from "firebase/firestore";
 import { useAuth } from "./useAuth";
 import { db } from "../lib/firebase";
 import { spendUserCredits, userHasEnoughCredits } from "../lib/creditsFirestore";
+import { usuarioCreditosIlimitados, usuarioSaldoTotal } from "../lib/creditWallet";
 
 /**
  * Sistema de créditos (saldo comprado + bônus) na coleção usuarios/{uid}.
  * Consome bônus antes do saldo principal.
+ * creditos_ilimitados / role admin no Firestore → não debita (definir só no Console).
  */
 export function useCreditSystem() {
-  const { user } = useAuth();
+  const { user, credits, isAdmin: isAdminClaim } = useAuth();
+
+  const isAdmin = Boolean(isAdminClaim);
 
   const checkCredits = useCallback(
     async (custo) => {
       if (!user) return false;
+      if (isAdmin) return true;
+      try {
+        const snap = await getDoc(doc(db, "usuarios", user.uid));
+        if (snap.exists() && usuarioCreditosIlimitados(snap.data())) return true;
+      } catch {
+        /* rede / permissão */
+      }
       return userHasEnoughCredits(db, user.uid, custo);
     },
-    [user],
+    [user, isAdmin],
   );
 
   const consumirCreditos = useCallback(
     async (custo, descricao) => {
       if (!user) throw new Error("Não autenticado");
+      if (isAdmin) return;
+      const snap = await getDoc(doc(db, "usuarios", user.uid));
+      if (snap.exists() && usuarioCreditosIlimitados(snap.data())) return;
       await spendUserCredits(db, user.uid, custo, descricao);
     },
-    [user],
+    [user, isAdmin],
   );
 
-  return { checkCredits, consumirCreditos };
+  const saldoExibicao = useMemo(() => {
+    if (isAdmin) return credits ?? null;
+    return credits ?? null;
+  }, [isAdmin, credits]);
+
+  return { checkCredits, consumirCreditos, saldoExibicao, isAdmin };
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -264,3 +264,33 @@ strong, b  { font-weight: 600; }
 @media (min-width: 769px) {
   .nav-mobile-btn { display: none !important; }
 }
+
+/* Área de toque mínima (~44px) em mobile — botões e CTAs de navegação */
+@media (max-width: 768px) {
+  button:not(.no-touch-min),
+  [role="button"]:not(.no-touch-min),
+  input[type="submit"]:not(.no-touch-min) {
+    min-height: 44px;
+    min-width: 44px;
+  }
+  nav a[href],
+  footer a[href],
+  .credit-gate-wrapper button {
+    min-height: 44px;
+    min-width: 44px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+  }
+  .politician-links a,
+  .source-links a,
+  .presenca-link a {
+    padding: 10px 12px;
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    box-sizing: border-box;
+  }
+}

--- a/frontend/src/lib/creditWallet.js
+++ b/frontend/src/lib/creditWallet.js
@@ -1,0 +1,17 @@
+/**
+ * Leitura de flags de carteira em usuarios/{uid} (Firestore).
+ * creditos_ilimitados e role admin no documento — definidos só via Console/Admin SDK.
+ */
+
+export function usuarioCreditosIlimitados(data) {
+  if (!data || typeof data !== "object") return false;
+  if (data.creditos_ilimitados === true) return true;
+  if (data.role === "admin") return true;
+  if (data.isAdmin === true) return true;
+  return false;
+}
+
+export function usuarioSaldoTotal(data) {
+  if (!data) return 0;
+  return Number(data.creditos ?? 0) + Number(data.creditos_bonus ?? 0);
+}

--- a/frontend/src/lib/creditsFirestore.js
+++ b/frontend/src/lib/creditsFirestore.js
@@ -11,6 +11,7 @@ import {
   serverTimestamp,
   collection,
 } from "firebase/firestore";
+import { usuarioCreditosIlimitados } from "./creditWallet";
 
 function histDocId() {
   return `${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
@@ -53,11 +54,19 @@ export async function spendUserCredits(db, userId, custo, descricao) {
     );
   }
 
+  const preData = preCheck.data();
+  if (usuarioCreditosIlimitados(preData)) {
+    return;
+  }
+
   await runTransaction(db, async (tx) => {
     const snap = await tx.get(ref);
     if (!snap.exists()) throw new Error("Perfil não encontrado. Recarregue a página.");
 
     const dados = snap.data();
+    if (usuarioCreditosIlimitados(dados)) {
+      return;
+    }
     const saldoComprado = Number(dados.creditos ?? 0);
     const saldoBonus = Number(dados.creditos_bonus ?? 0);
     const total = saldoComprado + saldoBonus;
@@ -105,6 +114,7 @@ export async function userHasEnoughCredits(db, userId, custo) {
   const snap = await getDoc(doc(db, "usuarios", userId));
   if (!snap.exists()) return false;
   const d = snap.data();
+  if (usuarioCreditosIlimitados(d)) return true;
   const total = Number(d.creditos ?? 0) + Number(d.creditos_bonus ?? 0);
   return total >= amount;
 }

--- a/frontend/src/pages/PoliticoPage.jsx
+++ b/frontend/src/pages/PoliticoPage.jsx
@@ -233,6 +233,7 @@ export default function PoliticoPage() {
               const getEmendasParlamentar = httpsCallable(functions, "getEmendasParlamentar");
               const er = await getEmendasParlamentar({
                 nomeAutor: nomeBusca,
+                codigoAutor: Number.isFinite(idCamaraBusca) ? idCamaraBusca : undefined,
                 politicoDocId: id,
                 anos: anosCeap,
                 maxEmendasComDocumentos: 15,
@@ -602,7 +603,7 @@ export default function PoliticoPage() {
             <PresencaSection politico={pol} colecao={col} politicoId={id} />
           </SectionCard>
           <SectionCard title="Produção Legislativa (Resumo)" icon="📚">
-            <ProjetosSection deputadoId={id} colecao={col} />
+            <ProjetosSection deputadoId={id} idCamara={pol.idCamara || id} colecao={col} />
           </SectionCard>
         </div>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">

--- a/functions/index.js
+++ b/functions/index.js
@@ -710,10 +710,10 @@ exports.getAuditoriaPolitico = onCall(OPTS, async (req) => {
 
 const sleepMs = (ms) => new Promise((r) => setTimeout(r, ms));
 
-async function portalFetchEmendasPorAno(nomeAutorUpper, ano) {
+async function portalFetchEmendasPorAno(ano, query) {
   const out = [];
   for (let p = 1; p <= 50; p++) {
-    const path = `/api-de-dados/emendas?ano=${ano}&nomeAutor=${encodeURIComponent(nomeAutorUpper)}&pagina=${p}`;
+    const path = `/api-de-dados/emendas?ano=${ano}&${query}&pagina=${p}`;
     let page;
     try {
       page = await portalApiGet(path);
@@ -766,6 +766,10 @@ exports.getEmendasParlamentar = onCall(OPTS, async (req) => {
 
   const body = req.data || {};
   const nomeAutor = String(body.nomeAutor || body.nome || '').trim();
+  const codigoAutorRaw = body.codigoAutor ?? body.idAutor ?? body.idCamara;
+  const codigoAutor = codigoAutorRaw != null && String(codigoAutorRaw).trim() !== ''
+    ? String(codigoAutorRaw).replace(/\D/g, '')
+    : '';
   const politicoDocId = String(body.politicoDocId || body.deputadoId || '').trim();
   const maxComDocs = Math.min(20, Math.max(0, Number(body.maxEmendasComDocumentos) || 12));
 
@@ -773,11 +777,11 @@ exports.getEmendasParlamentar = onCall(OPTS, async (req) => {
   if (!anos || anos.length === 0) anos = defaultCeapAnos();
   anos = [...new Set(anos)].sort((a, b) => b - a);
 
-  if (!nomeAutor || !politicoDocId) {
-    throw new HttpsError('invalid-argument', 'nomeAutor e politicoDocId são obrigatórios.');
+  if ((!nomeAutor && !codigoAutor) || !politicoDocId) {
+    throw new HttpsError('invalid-argument', 'politicoDocId e nomeAutor ou codigoAutor são obrigatórios.');
   }
 
-  const nomeQuery = normalizeNomePortalAutor(nomeAutor);
+  const nomeQuery = nomeAutor ? normalizeNomePortalAutor(nomeAutor) : '';
   const byCodigo = new Map();
 
   function anoDoCodigoEmenda(cod) {
@@ -799,7 +803,13 @@ exports.getEmendasParlamentar = onCall(OPTS, async (req) => {
 
   try {
     for (const ano of anos) {
-      const chunk = await portalFetchEmendasPorAno(nomeQuery, ano);
+      let chunk = [];
+      if (codigoAutor) {
+        chunk = await portalFetchEmendasPorAno(ano, `codigoAutor=${encodeURIComponent(codigoAutor)}`);
+      }
+      if (chunk.length === 0 && nomeQuery) {
+        chunk = await portalFetchEmendasPorAno(ano, `nomeAutor=${encodeURIComponent(nomeQuery)}`);
+      }
       for (const e of chunk) {
         const cod = e?.codigoEmenda;
         if (!cod) continue;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Targets the deputado hotpage and shared credit UX without adopting the legacy `users` collection (app uses **`usuarios/{uid}`** per `.cursorrules`).

### Credits (Fix 1–2 aligned)
- New `creditWallet.js`: `creditos_ilimitados === true` or `role === 'admin'` or `isAdmin` → unlimited.
- `spendUserCredits` / `userHasEnoughCredits`: skip debit and return sufficient when unlimited.
- `useCreditSystem`: Custom Claim admin or Firestore unlimited → `checkCredits` true, `consumirCreditos` no-op; shows saldo in `CreditGate`.
- `useAuth`: `isAdmin` true if `role === 'admin'` **or** `isAdmin` field.
- **Firestore rules**: `creditos_ilimitados` added to `touchesCriticalFields` so clients cannot self-grant.

**Your manual step (Console):** edit **`usuarios/{seu_uid}`** (not `users`) and set e.g. `creditos_ilimitados: true` and/or `role: "admin"`. Optional: set Custom Claim `admin` via Admin SDK for dropdown admin routes.

### CreditGate (Fix 3)
- First **3** child nodes visible; remainder in a blurred, height-capped block with unlock overlay and saldo line.

### Touch targets (Fix 4)
- Mobile-only CSS for min 44px on nav/footer buttons, CreditGate unlock, and utility classes `.politician-links` / `.source-links` / `.presenca-link` (apply in JSX later if needed).

### Emendas (Fix 5)
- `getEmendasParlamentar`: accepts `codigoAutor` / `idCamara`; tries **`codigoAutor`** query first, falls back to **`nomeAutor`**.
- `PoliticoPage` passes `codigoAutor: idCamara` when available.

### Verba gabinete (Fix 6)
- When pessoal subcollection is empty: short honest copy + links to Portal da Transparência and Câmara (no fake API).

### Proposições (Fix 8)
- `ProjetosSection` takes **`idCamara`**, uses **`idLegislatura=57`**, paginates API, filters where first author id matches `idCamara`.

### Presença (Fix 9)
- Official Câmara links use **`idCamara`** when present (not Firestore doc id).
- Copy notes legislatura **57**.

### Logo defect (mobile)
- **`LogoOrb.jsx`** with `useId()`-scoped gradient IDs so multiple SVGs on a page do not share `#orbA` (fixes wrong colors / gaps at top of orb).

### Not done in code
- Firebase `functions:log` / timeout tuning for forensic engine (run locally after login).
- No codenames in code or PR text.

## Deploy
- `firebase deploy --only firestore:rules,functions:getEmendasParlamentar` after merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a104e531-5741-475b-a073-18bba97d95ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a104e531-5741-475b-a073-18bba97d95ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

