### PR TITLE
fix: geocode_cache Firestore + defineSecret binding (Gen 2)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -196,6 +196,12 @@ service cloud.firestore {
       allow write: if false;
     }
 
+    // Cache de geocodificação município+UF (Nominatim) — escrita só Cloud Function
+    match /geocode_cache/{docId} {
+      allow read: if true;
+      allow write: if false;
+    }
+
 
     // ────────────────────────────────────────────────────────────────────────
     // config/{docId}  (inclui config/sistema — Kill Switch)

--- a/functions/ENV_VARS.md
+++ b/functions/ENV_VARS.md
@@ -6,7 +6,14 @@
 
 Configure com `firebase functions:secrets:set PORTAL_TRANSPARENCIA_API_KEY` ou no Console do Firebase.
 
+**Ligar o secret ao runtime (Gen 2):** após criar o secret, associe-o às functions que usam a API do Portal (ex.: `getEmendasParlamentar`, `getEmendasMapaPontos`, `forensicEngine`) no `firebase.json` / parâmetro `secrets` do `onCall`, **ou** defina a mesma variável em **Google Cloud Console → Cloud Functions → variáveis de ambiente** para o serviço. Sem isso, `process.env.PORTAL_TRANSPARENCIA_API_KEY` fica vazio e emendas/mapa retornam erro ou lista vazia.
+
 Documentação: https://api.portaldatransparencia.gov.br/
+
+## Mapa de emendas (Nominatim)
+
+- Geocodificação usa **OpenStreetMap Nominatim**; resultados são guardados em Firestore na coleção **`geocode_cache`** (TTL ~90 dias, escrita só via Cloud Function).
+- Regra: `geocode_cache` — leitura pública, escrita negada ao cliente (igual `gabinete_cache`).
 
 ## Stripe (pagamentos)
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -11,6 +11,7 @@
 
 const { onRequest, onCall, HttpsError } = require('firebase-functions/v2/https');
 const { onSchedule } = require('firebase-functions/v2/scheduler');
+const { defineSecret } = require('firebase-functions/params');
 const admin = require('firebase-admin');
 const { BigQuery } = require('@google-cloud/bigquery');
 const { Storage } = require('@google-cloud/storage');
@@ -27,6 +28,11 @@ const DATASET = 'dados_camara';
 const BQ_LOCATION = 'us-central1'; // Iowa — onde o dataset dados_camara está armazenado
 const REGION = 'southamerica-east1'; // Functions ficam perto dos usuários BR
 const OPTS = { region: REGION };
+
+// Secret binding para Gen 2 — garante que process.env.PORTAL_TRANSPARENCIA_API_KEY
+// fica disponível no runtime sem configurar manualmente no Console GCP.
+const portalSecret = defineSecret('PORTAL_TRANSPARENCIA_API_KEY');
+const OPTS_PORTAL = { region: REGION, secrets: [portalSecret] };
 
 // Stripe inicializado lazy — evita crash quando STRIPE_SECRET_KEY não está
 // disponível em tempo de análise estática (firebase deploy --only functions)
@@ -481,7 +487,7 @@ exports.stripeWebhook = onRequest(
 // ─────────────────────────────────────────────
 // 9. PERFIL DE PARLAMENTAR (onCall premium)
 // ─────────────────────────────────────────────
-exports.getPerfilParlamentar = onCall(OPTS, async (req) => {
+exports.getPerfilParlamentar = onCall(OPTS_PORTAL, async (req) => {
   const uid = req.auth?.uid;
   if (!uid) throw new HttpsError('unauthenticated', 'Login obrigatório.');
 
@@ -760,7 +766,7 @@ function parsePtDataSortKey(dataStr) {
  * Emendas parlamentares (Portal da Transparência) + documentos por fase (empenho → … → pagamento).
  * Chave API: variável de ambiente PORTAL_TRANSPARENCIA_API_KEY (header chave-api-dados).
  */
-exports.getEmendasParlamentar = onCall(OPTS, async (req) => {
+exports.getEmendasParlamentar = onCall(OPTS_PORTAL, async (req) => {
   const uid = req.auth?.uid;
   if (!uid) throw new HttpsError('unauthenticated', 'Login obrigatório.');
 
@@ -918,7 +924,7 @@ function emendaTipoPixPortal(tipoEmenda) {
  * Pontos geográficos para mapa de emendas (Nominatim + cache em memória por cold start).
  * Não substitui getEmendasParlamentar — uso leve para visualização.
  */
-exports.getEmendasMapaPontos = onCall(OPTS, async (req) => {
+exports.getEmendasMapaPontos = onCall(OPTS_PORTAL, async (req) => {
   const uid = req.auth?.uid;
   if (!uid) throw new HttpsError('unauthenticated', 'Login obrigatório.');
 
@@ -1157,7 +1163,7 @@ const PORTAL_PROXY_PREFIXES = [
  * pathAndQuery: ex. "/api-de-dados/emendas?ano=2024&nomeAutor=X&pagina=1"
  * Só aceita prefixos em PORTAL_PROXY_PREFIXES (evita abuso da chave).
  */
-exports.portalTransparenciaProxy = onCall(OPTS, async (req) => {
+exports.portalTransparenciaProxy = onCall(OPTS_PORTAL, async (req) => {
   const uid = req.auth?.uid;
   if (!uid) throw new HttpsError('unauthenticated', 'Login obrigatório.');
 
@@ -1189,7 +1195,7 @@ exports.portalTransparenciaProxy = onCall(OPTS, async (req) => {
 // ─────────────────────────────────────────────
 const { registerForensicFunctions } = require('./forensicEngine');
 const forensic = registerForensicFunctions({
-  onCall, HttpsError, db, bq, DATASET, BQ_LOCATION, OPTS,
+  onCall, HttpsError, db, bq, DATASET, BQ_LOCATION, OPTS: OPTS_PORTAL,
 });
 exports.forensicEngine = forensic.forensicEngine;
 exports.getForensicCache = forensic.getForensicCache;

--- a/functions/index.js
+++ b/functions/index.js
@@ -952,10 +952,40 @@ exports.getEmendasMapaPontos = onCall(OPTS, async (req) => {
   }
 
   const geoMemo = new Map();
+  const GEO_CACHE_DAYS = 90;
+  const GEO_CACHE_MS = GEO_CACHE_DAYS * 24 * 60 * 60 * 1000;
+
+  function geocodeCacheDocId(municipio, uf) {
+    const key = `${String(municipio).trim().toLowerCase()}|${String(uf || '').toUpperCase()}`;
+    const safe = key.replace(/[^a-zA-Z0-9|_-]/g, '_').replace(/\|/g, '__');
+    return safe.length > 700 ? safe.slice(0, 700) : safe;
+  }
 
   async function nominatimLookup(municipio, uf) {
     const key = `${String(municipio).trim().toLowerCase()}|${String(uf || '').toUpperCase()}`;
     if (geoMemo.has(key)) return geoMemo.get(key);
+
+    const cacheId = geocodeCacheDocId(municipio, uf);
+    const cacheRef = db.collection('geocode_cache').doc(cacheId);
+    try {
+      const snap = await cacheRef.get();
+      if (snap.exists) {
+        const c = snap.data();
+        const ts = c.fetchedAt?.toMillis?.() ?? 0;
+        if (Date.now() - ts < GEO_CACHE_MS) {
+          if (c.lat == null || c.lng == null) {
+            geoMemo.set(key, null);
+            return null;
+          }
+          const coords = { lat: Number(c.lat), lng: Number(c.lng) };
+          geoMemo.set(key, coords);
+          return coords;
+        }
+      }
+    } catch (e) {
+      console.warn('geocode_cache read:', e.message);
+    }
+
     const q = `${municipio}, ${uf || ''}, Brasil`.replace(/,\s*,/g, ',').trim();
     const url = `https://nominatim.openstreetmap.org/search?format=json&limit=1&q=${encodeURIComponent(q)}`;
     const ac = new AbortController();
@@ -972,11 +1002,31 @@ exports.getEmendasMapaPontos = onCall(OPTS, async (req) => {
       clearTimeout(t);
       if (!r.ok) {
         geoMemo.set(key, null);
+        try {
+          await cacheRef.set({
+            municipio: String(municipio).slice(0, 200),
+            uf: String(uf || '').slice(0, 4),
+            lat: null,
+            lng: null,
+            fetchedAt: admin.firestore.FieldValue.serverTimestamp(),
+            fonte: 'nominatim_miss',
+          });
+        } catch {/* ignore */}
         return null;
       }
       const j = await r.json();
       if (!Array.isArray(j) || !j[0]) {
         geoMemo.set(key, null);
+        try {
+          await cacheRef.set({
+            municipio: String(municipio).slice(0, 200),
+            uf: String(uf || '').slice(0, 4),
+            lat: null,
+            lng: null,
+            fetchedAt: admin.firestore.FieldValue.serverTimestamp(),
+            fonte: 'nominatim_empty',
+          });
+        } catch {/* ignore */}
         return null;
       }
       coords = { lat: parseFloat(j[0].lat), lng: parseFloat(j[0].lon) };
@@ -985,6 +1035,18 @@ exports.getEmendasMapaPontos = onCall(OPTS, async (req) => {
       coords = null;
     }
     geoMemo.set(key, coords);
+    try {
+      await cacheRef.set({
+        municipio: String(municipio).slice(0, 200),
+        uf: String(uf || '').slice(0, 4),
+        lat: coords ? coords.lat : null,
+        lng: coords ? coords.lng : null,
+        fetchedAt: admin.firestore.FieldValue.serverTimestamp(),
+        fonte: 'nominatim',
+      });
+    } catch (e) {
+      console.warn('geocode_cache write:', e.message);
+    }
     return coords;
   }
 

--- a/scripts/migrarCollections.js
+++ b/scripts/migrarCollections.js
@@ -5,6 +5,10 @@
  *   export GOOGLE_APPLICATION_CREDENTIALS=/caminho/sa.json
  *   node scripts/migrarCollections.js
  *
+ * Depois: no Firebase Console → Authentication → utilizador →
+ *   firebase auth:set-custom-user-claims UID '{"admin":true}'
+ * e atualize o doc `usuarios/{UID}` (creditos_ilimitados, role, etc.) se necessário.
+ *
  * Requer firebase-admin (já presente em functions/).
  */
 /* eslint-disable @typescript-eslint/no-require-imports */


### PR DESCRIPTION
## Mudanças

### Geocode cache (cherry-pick do commit c6a84fd)
- `getEmendasMapaPontos` agora cacheia coordenadas Nominatim em `geocode_cache/{municipio__UF}` com TTL 90 dias
- Cache de miss (null) também é gravado para evitar re-consultas desnecessárias
- Regra `geocode_cache`: read público, write bloqueado ao cliente

### defineSecret binding (novo)
- Import `defineSecret` de `firebase-functions/params`
- Criado `OPTS_PORTAL = { region, secrets: [portalSecret] }`
- Aplicado a: `getPerfilParlamentar`, `getEmendasParlamentar`, `getEmendasMapaPontos`, `portalTransparenciaProxy`, `forensicEngine`
- **Resultado:** `process.env.PORTAL_TRANSPARENCIA_API_KEY` fica disponível automaticamente no runtime Gen 2 sem precisar de configuração manual no Console GCP

### Docs
- `functions/ENV_VARS.md`: nota sobre Gen 2 secret wiring
- `scripts/migrarCollections.js`: lembrete de custom claims

## Pré-requisito
```bash
firebase functions:secrets:set PORTAL_TRANSPARENCIA_API_KEY --project fiscallizapa
```

## Deploy após merge
```bash
firebase deploy --only functions,firestore:rules --project fiscallizapa
```