### PR TITLE
fix: remove Stripe vars from workflow .env (overlap with GCP secrets)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,8 +52,6 @@ jobs:
           echo "DB_PASS=${{ secrets.DB_PASS }}" >> .env
           echo "DB_NAME=${{ secrets.DB_NAME }}" >> .env
           echo "PORTAL_TRANSPARENCIA_API_KEY=${{ secrets.PORTAL_TRANSPARENCIA_API_KEY }}" >> .env
-          echo "STRIPE_SECRET_KEY=${{ secrets.STRIPE_SECRET_KEY }}" >> .env
-          echo "STRIPE_WEBHOOK_SECRET=${{ secrets.STRIPE_WEBHOOK_SECRET }}" >> .env
         working-directory: functions
 
       - name: Deploy Functions + Firestore rules


### PR DESCRIPTION
stripeWebhook deploy falhou com 'Secret environment variable overlaps non secret environment variable: STRIPE_WEBHOOK_SECRET'. As chaves Stripe já estão configuradas como GCP secrets — remover do .env evita conflito.