### PR TITLE
fix(dossie): CEAP multi-ano, teto correto no desempenho e emendas Portal

### DIFF
--- a/frontend/src/components/EmendasAba.jsx
+++ b/frontend/src/components/EmendasAba.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { collection, getDocs } from "firebase/firestore";
 import { db } from "../lib/firebase";
 import { normalizeUF } from "./SocialContext";
-import { anosCeapLegislaturaAtual } from "../utils/legislatura";
+import { anosCeapHistoricoCompleto } from "../utils/legislatura";
 
 const UF_VALIDAS = new Set(["AC","AL","AM","AP","BA","CE","DF","ES","GO","MA","MG","MS","MT","PA","PB","PE","PI","PR","RJ","RN","RO","RR","RS","SC","SE","SP","TO"]);
 
@@ -112,7 +112,7 @@ export default function EmendasAba({ deputadoId, nomeDeputado, emendasOverride, 
     return <div style={{ padding: '20px', color: 'var(--text-muted)', textAlign: 'center' }}>Carregando emendas parlamentares...</div>;
   }
 
-  const anosTxt = anosCeapLegislaturaAtual().join(", ");
+  const anosTxt = anosCeapHistoricoCompleto().join(", ");
 
   if (emendas.length === 0) {
     return (

--- a/frontend/src/components/PerformanceTab.jsx
+++ b/frontend/src/components/PerformanceTab.jsx
@@ -14,9 +14,13 @@
  *        (engine 13_ingest_presencas.py popula: presencas/{id} e proposicoes_proprias/{id})
  */
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { doc, getDoc } from "firebase/firestore";
-import { db }          from "../lib/firebase";
+import { httpsCallable } from "firebase/functions";
+import { db, functions } from "../lib/firebase";
+import { parseCamaraValorReais } from "../utils/moneyCamara";
+import { normalizeUF } from "./SocialContext";
+import { anosCeapHistoricoCompleto } from "../utils/legislatura";
 // ─── Constantes ───────────────────────────────────────────────────────────────
 const FIRA = "'Fira Code', 'Courier New', monospace";
 
@@ -116,6 +120,57 @@ function generateGabineteData(politico) {
 
   const percentual = Math.min(Math.max((gastos / limiteAnual) * 100, 5), 108);
   return { gastos: Math.abs(gastos), limite: limiteAnual, percentual };
+}
+
+function anoFromDespesaCamara(d) {
+  if (d?.ano != null && Number.isFinite(Number(d.ano))) return Number(d.ano);
+  const s = String(d?.dataDocumento || d?.datEmissao || "");
+  const m = s.match(/(\d{2})\/(\d{2})\/(\d{4})/);
+  if (m) return Number(m[3]);
+  const y = s.match(/(\d{4})/);
+  if (y) return Number(y[1]);
+  return new Date().getFullYear();
+}
+
+/** Métricas CEAP: compara gasto do ano de referência com teto anual (evita alarme falso multi-ano vs teto de 1 ano). */
+export function computeCeapTetoMetrics(despesasNormalizadas, ufRaw) {
+  const uf = normalizeUF(ufRaw, "") || String(ufRaw || "").toUpperCase().slice(0, 2);
+  const limiteAnual = CEAP_LIMITE_UF[uf] ?? CEAP_LIMITE_DEFAULT;
+  const anoAtual = new Date().getFullYear();
+  const minAno = 2019;
+
+  const porAno = {};
+  let gastoTotal = 0;
+  for (const d of despesasNormalizadas) {
+    const v = Number(d.valorLiquido ?? 0);
+    if (!Number.isFinite(v)) continue;
+    gastoTotal += v;
+    const ano = anoFromDespesaCamara(d);
+    const a = Number.isFinite(ano) ? ano : anoAtual;
+    porAno[a] = (porAno[a] ?? 0) + v;
+  }
+
+  const anosComDados = Object.keys(porAno).map(Number).filter((y) => y >= minAno && y <= anoAtual + 1).sort((a, b) => a - b);
+  const anoRef = anosComDados.length > 0 ? Math.max(...anosComDados) : anoAtual;
+  const gastoAnoRef = porAno[anoRef] ?? 0;
+  const percentualAnual = limiteAnual > 0 ? (gastoAnoRef / limiteAnual) * 100 : 0;
+
+  const primeiroAno = anosComDados.length > 0 ? Math.min(...anosComDados) : minAno;
+  const numAnosTeto = Math.max(1, anoRef - primeiroAno + 1);
+  const tetoAcumuladoEstimado = limiteAnual * numAnosTeto;
+  const percentualAcumuladoVsTetoMulti = tetoAcumuladoEstimado > 0 ? (gastoTotal / tetoAcumuladoEstimado) * 100 : 0;
+
+  return {
+    gastoAnoRef,
+    gastoTotalAcumulado: gastoTotal,
+    limiteAnual,
+    tetoAcumuladoEstimado,
+    percentualAnual,
+    percentualAcumuladoVsTetoMulti,
+    anoRef,
+    primeiroAno,
+    labelPeriodo: `${primeiroAno}–${anoRef}`,
+  };
 }
 
 // ─── Componentes internos ──────────────────────────────────────────────────────
@@ -242,7 +297,13 @@ function ProposicoesSection({ proposicoes }) {
 }
 
 // ─── Monitor de Teto de Gastos ────────────────────────────────────────────────
-function GastosMonitor({ gastos, limite, percentual }) {
+function GastosMonitor({ loading, metrics, fallbackGasto, fallbackLimite, fallbackPercentual }) {
+  const real = metrics && metrics.gastoAnoRef != null;
+  const gastoCard = real ? metrics.gastoAnoRef : fallbackGasto;
+  const limiteAnual = real ? metrics.limiteAnual : fallbackLimite;
+  const percentual = real ? metrics.percentualAnual : fallbackPercentual;
+  const anoRef = real ? metrics.anoRef : new Date().getFullYear();
+
   const isCritico  = percentual >= ALERTA_USO_CRITICO;
   const isElevado  = percentual >= ALERTA_USO_ELEVADO && !isCritico;
 
@@ -258,6 +319,16 @@ function GastosMonitor({ gastos, limite, percentual }) {
     ? { label: "🟡 USO ELEVADO",       color: "#c2410c", bg: "rgba(249,115,22,0.08)", border: "rgba(249,115,22,0.25)" }
     : { label: "✅ DENTRO DO LIMITE",  color: "#16a34a", bg: "rgba(34,197,94,0.08)",  border: "rgba(34,197,94,0.25)" };
 
+  if (loading) {
+    return (
+      <SectionBlock icon="💼" title="Monitor de Teto de Gastos" badge="CARREGANDO" badgeColor="#6b7280" badgeBg="#f3f4f6">
+        <div style={{ height: 72, borderRadius: 10, background: "linear-gradient(90deg,#f3f4f6 25%,#e5e7eb 50%,#f3f4f6 75%)", backgroundSize: "200% 100%", animation: "shimmer 1.2s ease-in-out infinite" }} />
+        <style>{`@keyframes shimmer { 0%{background-position:200% 0} 100%{background-position:-200% 0} }`}</style>
+        <p style={{ fontSize: 10, color: "#9ca3af", marginTop: 10 }}>Fonte: Câmara dos Deputados — dadosabertos.camara.leg.br</p>
+      </SectionBlock>
+    );
+  }
+
   return (
     <SectionBlock
       icon="💼"
@@ -266,23 +337,32 @@ function GastosMonitor({ gastos, limite, percentual }) {
       badgeColor={statusBadge.color}
       badgeBg={statusBadge.bg}
     >
-      {/* Valores principais */}
+      {!real && (
+        <p style={{ fontSize: 10, color: "#92400e", margin: "0 0 12px", padding: "8px 10px", background: "#fffbeb", borderRadius: 8, border: "1px solid #fde68a" }}>
+          Dados CEAP da API ainda não carregaram — exibindo referência ilustrativa. Abra o dossiê com login para atualizar.
+        </p>
+      )}
+
       <div style={{
         display: "grid", gridTemplateColumns: "1fr auto 1fr",
         alignItems: "center", gap: 16, marginBottom: 18,
       }}>
-        {/* Gasto atual */}
         <div>
           <div style={{ fontSize: 9, color: "#9ca3af", marginBottom: 4,
                         textTransform: "uppercase", letterSpacing: "0.06em" }}>
-            Gasto (CEAP)
+            Gasto (CEAP) — {anoRef}
           </div>
           <div style={{ fontFamily: FIRA, fontSize: 20, fontWeight: 700, color: barColor }}>
-            {gastos.toLocaleString("pt-BR", { style: "currency", currency: "BRL", maximumFractionDigits: 0 })}
+            {gastoCard.toLocaleString("pt-BR", { style: "currency", currency: "BRL", maximumFractionDigits: 0 })}
           </div>
+          {real && (
+            <div style={{ fontSize: 9, color: "#6b7280", marginTop: 4 }}>
+              Total acumulado {metrics.labelPeriodo}:{" "}
+              {metrics.gastoTotalAcumulado.toLocaleString("pt-BR", { style: "currency", currency: "BRL", maximumFractionDigits: 0 })}
+            </div>
+          )}
         </div>
 
-        {/* Percentual */}
         <div style={{ textAlign: "center" }}>
           <div style={{
             fontFamily: FIRA,
@@ -291,22 +371,20 @@ function GastosMonitor({ gastos, limite, percentual }) {
           }}>
             {percentual.toFixed(1)}<span style={{ fontSize: 14, fontWeight: 400 }}>%</span>
           </div>
-          <div style={{ fontSize: 9, color: "#9ca3af", marginTop: 2 }}>do teto</div>
+          <div style={{ fontSize: 9, color: "#9ca3af", marginTop: 2 }}>do teto anual {anoRef}</div>
         </div>
 
-        {/* Limite máximo */}
         <div style={{ textAlign: "right" }}>
           <div style={{ fontSize: 9, color: "#9ca3af", marginBottom: 4,
                         textTransform: "uppercase", letterSpacing: "0.06em" }}>
-            Teto Anual
+            Teto anual {anoRef}
           </div>
           <div style={{ fontFamily: FIRA, fontSize: 20, fontWeight: 700, color: "#6b7280" }}>
-            {limite.toLocaleString("pt-BR", { style: "currency", currency: "BRL", maximumFractionDigits: 0 })}
+            {limiteAnual.toLocaleString("pt-BR", { style: "currency", currency: "BRL", maximumFractionDigits: 0 })}
           </div>
         </div>
       </div>
 
-      {/* Barra de progresso */}
       <div style={{ marginBottom: 14 }}>
         <div style={{
           height: 16, borderRadius: 99, background: "#f0f0f0",
@@ -320,7 +398,6 @@ function GastosMonitor({ gastos, limite, percentual }) {
             transition: "width 0.8s cubic-bezier(0.4, 0, 0.2, 1)",
             position: "relative",
           }}>
-            {/* Riscado de textura para indicar valor próximo ao teto */}
             {isCritico && (
               <div style={{
                 position: "absolute", inset: 0, borderRadius: 99,
@@ -328,14 +405,12 @@ function GastosMonitor({ gastos, limite, percentual }) {
               }} />
             )}
           </div>
-          {/* Marcador de 95% */}
           <div style={{
             position: "absolute", top: 0, bottom: 0,
             left: "95%", width: 2,
             background: "rgba(239,68,68,0.5)",
           }} title="Limite de Alerta (95%)" />
         </div>
-        {/* Escala */}
         <div style={{ display: "flex", justifyContent: "space-between", marginTop: 4 }}>
           <span style={{ fontFamily: FIRA, fontSize: 9, color: "#9ca3af" }}>0%</span>
           <span style={{ fontFamily: FIRA, fontSize: 9, color: "#9ca3af", marginLeft: "70%" }}>95% ⚠️</span>
@@ -343,7 +418,6 @@ function GastosMonitor({ gastos, limite, percentual }) {
         </div>
       </div>
 
-      {/* Alerta de gasto crítico */}
       {isCritico && (
         <div style={{
           padding: "10px 14px", borderRadius: 10, marginBottom: 12,
@@ -353,20 +427,17 @@ function GastosMonitor({ gastos, limite, percentual }) {
             ⚠️ ALERTA DE EFICIÊNCIA — GASTO CRÍTICO
           </p>
           <p style={{ fontSize: 11, color: "#9ca3af", margin: 0 }}>
-            O parlamentar atingiu {percentual.toFixed(1)}% da cota anual. Padrão consistente
-            com gastos acelerados em período eleitoral. Recomenda-se auditoria das notas CEAP.
+            Em {anoRef}, o gasto CEAP atingiu {percentual.toFixed(1)}% do teto anual de referência para a UF.
+            Recomenda-se confrontar com as notas na Câmara.
           </p>
         </div>
       )}
 
-      {/* Teto mensal médio */}
-      <div style={{
-        display: "flex", gap: 12, flexWrap: "wrap",
-      }}>
+      <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
         {[
-          { label: "Teto/mês",     value: (limite / 12).toLocaleString("pt-BR", { style: "currency", currency: "BRL", maximumFractionDigits: 0 }) },
-          { label: "Saldo restante", value: Math.max(limite - gastos, 0).toLocaleString("pt-BR", { style: "currency", currency: "BRL", maximumFractionDigits: 0 }) },
-          { label: "Meses restantes (estimado)", value: gastos > 0 ? `~${Math.ceil((limite - gastos) / (gastos / 12))} meses` : "–" },
+          { label: "Teto/mês (ref.)", value: (limiteAnual / 12).toLocaleString("pt-BR", { style: "currency", currency: "BRL", maximumFractionDigits: 0 }) },
+          { label: "Saldo vs teto anual", value: Math.max(limiteAnual - gastoCard, 0).toLocaleString("pt-BR", { style: "currency", currency: "BRL", maximumFractionDigits: 0 }) },
+          ...(real ? [{ label: "% vs teto acum. (est.)", value: `${metrics.percentualAcumuladoVsTetoMulti.toFixed(1)}%` }] : []),
         ].map(m => (
           <div key={m.label} style={{
             flex: 1, minWidth: 120,
@@ -384,9 +455,12 @@ function GastosMonitor({ gastos, limite, percentual }) {
         ))}
       </div>
 
-      <p style={{ fontSize: 9, color: "#d1d5db", marginTop: 10 }}>
-        * CEAP — Cota para o Exercício da Atividade Parlamentar · Limite varia por estado
-        · Referência 2024 · Dados: BigQuery <code>fiscalizapa.ceap_ocr_extractions</code>
+      <p style={{ fontSize: 9, color: "#6b7280", marginTop: 10 }}>
+        Fonte: Câmara dos Deputados —{" "}
+        <a href="https://dadosabertos.camara.leg.br" target="_blank" rel="noopener noreferrer" style={{ color: "#15803d" }}>
+          dadosabertos.camara.leg.br
+        </a>
+        {" "}· Teto CEAP por UF (referência aproximada; conferir resolução vigente).
       </p>
     </SectionBlock>
   );
@@ -547,6 +621,10 @@ export default function PerformanceTab({
   onPayFull,
   unlocking,
   unlockError,
+  /** Despesas CEAP já normalizadas (valorLiquido em R$) vindas de getAuditoriaPolitico; null = ainda não carregado */
+  ceapDespesas = null,
+  ceapLoading = false,
+  ceapError = null,
 }) {
   const [livePresenca,      setLivePresenca     ] = useState(null);
   const [liveProposicoes,   setLiveProposicoes  ] = useState(null);
@@ -593,6 +671,11 @@ export default function PerformanceTab({
     : mockAtt;
 
   const proposicoesData = liveProposicoes ?? mockProp;
+
+  const ceapMetrics = useMemo(() => {
+    if (ceapDespesas === null || ceapError) return null;
+    return computeCeapTetoMetrics(ceapDespesas, politico?.uf ?? politico?.estado);
+  }, [ceapDespesas, ceapError, politico?.uf, politico?.estado]);
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
@@ -650,11 +733,19 @@ export default function PerformanceTab({
       {/* ─── 2. Proposições de Autoria Própria ─────────────────── */}
       <ProposicoesSection proposicoes={proposicoesData} />
 
+      {ceapError && (
+        <p style={{ fontSize: 11, color: "#b45309", margin: 0, padding: "8px 12px", background: "#fffbeb", borderRadius: 8, border: "1px solid #fde68a" }}>
+          CEAP (Câmara): {ceapError}
+        </p>
+      )}
+
       {/* ─── 3. Monitor de Teto de Gastos ──────────────────────── */}
       <GastosMonitor
-        gastos={gabinete.gastos}
-        limite={gabinete.limite}
-        percentual={gabinete.percentual}
+        loading={ceapLoading}
+        metrics={ceapMetrics}
+        fallbackGasto={gabinete.gastos}
+        fallbackLimite={gabinete.limite}
+        fallbackPercentual={gabinete.percentual}
       />
 
       {/* ─── 4. Análise do Oráculo (PAYWALL 200cr) ─────────────── */}
@@ -685,8 +776,8 @@ export default function PerformanceTab({
           unlocking={unlocking}
           unlockError={unlockError}
           credits={credits}
-          gastos={gabinete.gastos}
-          limite={gabinete.limite}
+          gastos={ceapMetrics ? ceapMetrics.gastoAnoRef : gabinete.gastos}
+          limite={ceapMetrics ? ceapMetrics.limiteAnual : gabinete.limite}
         />
       </div>
 

--- a/frontend/src/pages/DossiePage.jsx
+++ b/frontend/src/pages/DossiePage.jsx
@@ -39,7 +39,6 @@ import { Helmet }         from "react-helmet-async";
 import PageSkeleton       from "../components/PageSkeleton";
 import NetworkGraph       from "../components/NetworkGraph";
 import StickyHeader       from "../components/StickyHeader";
-import PerformanceTab     from "../components/PerformanceTab";
 import PoliticalTimeline  from "../components/PoliticalTimeline";
 import CabinetAudit       from "../components/CabinetAudit";
 import ForensicDashboard  from "../components/ForensicDashboard";
@@ -50,7 +49,8 @@ import ScoreForense from "../components/ScoreForense";
 import BotaoCobrarDeputado from "../components/BotaoCobrarDeputado";
 import { normalizeUF }    from "../components/SocialContext";
 import { parseCamaraValorReais } from "../utils/moneyCamara";
-import { anosCeapLegislaturaAtual } from "../utils/legislatura";
+import { anosCeapHistoricoCompleto, CEAP_HISTORICO_ANO_INICIO } from "../utils/legislatura";
+import PerformanceTab, { computeCeapTetoMetrics } from "../components/PerformanceTab";
 
 const CUSTO_FULL    = 200;
 const CUSTO_RESUMO  = 10;
@@ -64,6 +64,31 @@ function fmtBRL(v) {
 }
 // Alias seguro para formatCurrency (jamais R$ NaN)
 const formatCurrency = (v) => fmtBRL(v ?? 0);
+
+function absolutizeCamaraUrl(u) {
+  const s = String(u || "").trim();
+  if (!s) return "";
+  if (/^https?:\/\//i.test(s)) return s;
+  if (s.startsWith("//")) return `https:${s}`;
+  if (s.startsWith("/")) return `https://www.camara.leg.br${s}`;
+  return s;
+}
+
+function normalizeDespesaCeap(item, index) {
+  const rawNome = item?.txtFornecedor || item?.fornecedorNome || item?.nomeFornecedor;
+  const urlDoc = absolutizeCamaraUrl(item?.urlDocumento);
+  const cod = item?.codDocumento ?? item?.numDocumento ?? "";
+  return {
+    id: item?.id || urlDoc || `${cod}-${item?.dataDocumento || index}-${index}`,
+    valorLiquido: parseCamaraValorReais(item?.vlrLiquido ?? item?.valorLiquido ?? item?.valorDocumento ?? 0),
+    tipoDespesa: item?.txtDescricao || item?.tipoDespesa || "Sem categoria",
+    fornecedorNome: rawNome && String(rawNome).trim() ? String(rawNome).trim() : null,
+    dataDocumento: item?.datEmissao || item?.dataDocumento || "",
+    urlDocumento: urlDoc,
+    cnpjCpf: item?.txtCNPJCPF || item?.cnpjCpf || item?.cnpjCpfFornecedor || "",
+    ano: item?.ano,
+  };
+}
 
 function sessionKey(id, tipo = "full") {
   return `dossie_${tipo}_${id}`;
@@ -235,19 +260,29 @@ function IdentitySection({ politico, scoreForense, alertasResumo = [], custoCont
 }
 
 // ─── SEÇÃO 2: Monitor de Gastos CEAP (GRÁTIS) — resumo + link fonte oficial ───
-function CeapMonitorSection({ politico }) {
+function CeapMonitorSection({ politico, ceapTotalAcumulado, ceapPeriodoLabel, ceapLoading }) {
   const idCamara = politico?.idCamara ?? politico?.id_camara;
   const ceapUrl = idCamara
     ? `https://www.camara.leg.br/deputados/${idCamara}/despesas`
     : `https://portaldatransparencia.gov.br/verbas-indenizatorias/consulta`;
   const dossiePath = politico?.id ? `/dossie/${politico.id}` : "/ranking";
+  const gastoExibido = ceapTotalAcumulado != null
+    ? ceapTotalAcumulado
+    : parseCamaraValorReais(politico?.gastosCeapTotal ?? politico?.totalGasto ?? 0);
+  const labelGasto = ceapPeriodoLabel
+    ? `Total CEAP (${ceapPeriodoLabel})`
+    : "Gasto Total";
 
   return (
     <Card>
       <SectionHeader icon="💰" title="Monitor de Gastos CEAP" badge="GRÁTIS" />
       <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(120px, 1fr))", gap: 10, marginBottom: 16 }}>
         {[
-          { label: "Gasto Total", value: fmtBRL(politico?.gastosCeapTotal ?? politico?.totalGasto ?? 0), color: "#C82538" },
+          {
+            label: labelGasto,
+            value: ceapLoading ? "…" : fmtBRL(gastoExibido),
+            color: "#C82538",
+          },
           { label: "Presença", value: politico?.presenca != null ? `${politico.presenca}%` : "—", color: "#2E7F18" },
         ].map((m) => (
           <div
@@ -276,6 +311,8 @@ function CeapMonitorSection({ politico }) {
         ))}
       </div>
       <p style={{ fontSize: 11, color: "#6b7280", lineHeight: 1.6 }}>
+        Soma das despesas CEAP na API da Câmara
+        {ceapPeriodoLabel ? ` (${ceapPeriodoLabel})` : ` (desde ${CEAP_HISTORICO_ANO_INICIO})`}.
         Detalhamento com notas fiscais, Motor Forense TransparenciaBR e gráficos está no{" "}
         <strong>Dossiê de Notas Fiscais (CEAP)</strong> na{" "}
         <Link to={dossiePath} style={{ color: "#15803D", fontWeight: 600 }}>
@@ -1010,6 +1047,13 @@ export default function DossiePage() {
   const [emendasPortalErr, setEmendasPortalErr] = useState(null);
   const [mapaEmendasData,  setMapaEmendasData ] = useState(null);
   const [forensicHeader,   setForensicHeader ] = useState(null);
+  /** CEAP agregado (2019→ano atual) via getAuditoriaPolitico — alinha teto e totais com a API da Câmara */
+  const [ceapState, setCeapState] = useState({
+    status: "idle",
+    despesas: null,
+    error: null,
+    anosCeap: null,
+  });
 
   const pdfRef = useRef(null);
 
@@ -1141,6 +1185,50 @@ export default function DossiePage() {
   }, [politico?.idCamara, politico?.nome, politico?.nomeCompleto]);
 
   useEffect(() => {
+    setCeapState({ status: "idle", despesas: null, error: null, anosCeap: null });
+  }, [id]);
+
+  useEffect(() => {
+    if (!user || !id || !politico) return;
+    let cancelled = false;
+    const nome = politico.nome || politico.nomeCompleto;
+    const idC = politico.idCamara != null ? Number(politico.idCamara) : null;
+    if (!nome && !Number.isFinite(idC)) {
+      const anos = anosCeapHistoricoCompleto();
+      setCeapState({ status: "ready", despesas: [], error: null, anosCeap: anos });
+      return;
+    }
+    const anos = anosCeapHistoricoCompleto();
+    setCeapState((s) => ({ ...s, status: "loading", error: null }));
+    (async () => {
+      try {
+        const fn = httpsCallable(functions, "getAuditoriaPolitico");
+        const result = await fn({
+          nome: nome || undefined,
+          idCamara: Number.isFinite(idC) ? idC : undefined,
+          anos,
+        });
+        if (cancelled) return;
+        const raw = Array.isArray(result?.data?.despesas) ? result.data.despesas : [];
+        const despesas = raw.map(normalizeDespesaCeap);
+        const anosCeap = Array.isArray(result?.data?.anosCeap) && result.data.anosCeap.length
+          ? result.data.anosCeap
+          : anos;
+        setCeapState({ status: "ready", despesas, error: null, anosCeap });
+      } catch (e) {
+        if (cancelled) return;
+        setCeapState({
+          status: "error",
+          despesas: null,
+          error: e?.message || "Falha ao carregar CEAP.",
+          anosCeap: anos,
+        });
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [user, id, politico?.id, politico?.nome, politico?.nomeCompleto, politico?.idCamara]);
+
+  useEffect(() => {
     if (!user || !id || !politico) return;
     let cancelled = false;
     const nome = politico.nome || politico.nomeCompleto;
@@ -1153,7 +1241,7 @@ export default function DossiePage() {
           politicoDocId: id,
           nomeAutor: nome || undefined,
           codigoAutor: Number.isFinite(idC) ? idC : undefined,
-          anos: anosCeapLegislaturaAtual(),
+          anos: anosCeapHistoricoCompleto(),
         });
         if (!cancelled) {
           setEmendasPortal(result.data?.emendas ?? []);
@@ -1183,7 +1271,7 @@ export default function DossiePage() {
           politicoDocId: id,
           nomeAutor: nome || undefined,
           codigoAutor: Number.isFinite(idC) ? idC : undefined,
-          anos: anosCeapLegislaturaAtual(),
+          anos: anosCeapHistoricoCompleto(),
           maxPontos: 20,
         });
         if (!cancelled) setMapaEmendasData(result.data || null);
@@ -1215,10 +1303,15 @@ export default function DossiePage() {
     return () => { cancelled = true; };
   }, [id, politico?.idCamara]);
 
-  const custoContribuinteCeap = useMemo(
-    () => parseCamaraValorReais(politico?.gastosCeapTotal ?? politico?.totalGasto ?? 0),
-    [politico?.gastosCeapTotal, politico?.totalGasto],
-  );
+  const ceapMetricsDossie = useMemo(() => {
+    if (ceapState.status !== "ready" || !Array.isArray(ceapState.despesas)) return null;
+    return computeCeapTetoMetrics(ceapState.despesas, politico?.uf ?? politico?.estado);
+  }, [ceapState.status, ceapState.despesas, politico?.uf, politico?.estado]);
+
+  const custoContribuinteCeap = useMemo(() => {
+    if (ceapMetricsDossie) return ceapMetricsDossie.gastoTotalAcumulado;
+    return parseCamaraValorReais(politico?.gastosCeapTotal ?? politico?.totalGasto ?? 0);
+  }, [ceapMetricsDossie, politico?.gastosCeapTotal, politico?.totalGasto]);
 
   const emendasKpis = useMemo(() => {
     const list = Array.isArray(emendasPortal) ? emendasPortal : [];
@@ -1477,8 +1570,12 @@ export default function DossiePage() {
             marginBottom: 20,
           }}>
             <div style={{ background: "#fff", border: "1px solid #e2e8f0", borderRadius: 12, padding: "12px 14px" }}>
-              <div style={{ fontSize: 9, color: "#94a3b8", fontWeight: 700, letterSpacing: "0.06em" }}>CUSTO CEAP (REFERÊNCIA)</div>
-              <div style={{ fontSize: 16, fontWeight: 800, color: "#1e293b" }}>{fmtBRL(custoContribuinteCeap)}</div>
+              <div style={{ fontSize: 9, color: "#94a3b8", fontWeight: 700, letterSpacing: "0.06em" }}>
+                CUSTO CEAP {ceapMetricsDossie ? `(${ceapMetricsDossie.labelPeriodo})` : "(REFERÊNCIA)"}
+              </div>
+              <div style={{ fontSize: 16, fontWeight: 800, color: "#1e293b" }}>
+                {ceapState.status === "loading" || ceapState.status === "idle" ? "…" : fmtBRL(custoContribuinteCeap)}
+              </div>
             </div>
             <div style={{ background: "#fff", border: "1px solid #e2e8f0", borderRadius: 12, padding: "12px 14px" }}>
               <div style={{ fontSize: 9, color: "#94a3b8", fontWeight: 700, letterSpacing: "0.06em" }}>EMENDAS · EMPENHADO</div>
@@ -1503,6 +1600,9 @@ export default function DossiePage() {
                 onPayFull={handlePayFull}
                 unlocking={unlocking}
                 unlockError={unlockError}
+                ceapLoading={ceapState.status === "idle" || ceapState.status === "loading"}
+                ceapDespesas={ceapState.status === "ready" ? ceapState.despesas : null}
+                ceapError={ceapState.status === "error" ? ceapState.error : null}
               />
             )}
 
@@ -1646,7 +1746,12 @@ export default function DossiePage() {
 
             {/* ─── SEÇÃO 2: Monitor de Gastos CEAP (2 créditos) ─────── */}
             <CreditGate custo={2} descricao="Dossiê — CEAP detalhado">
-              <CeapMonitorSection politico={politico} />
+              <CeapMonitorSection
+                politico={politico}
+                ceapLoading={ceapState.status === "idle" || ceapState.status === "loading"}
+                ceapTotalAcumulado={ceapMetricsDossie?.gastoTotalAcumulado ?? null}
+                ceapPeriodoLabel={ceapMetricsDossie?.labelPeriodo ?? null}
+              />
             </CreditGate>
 
             {/* ─── SEÇÃO 2B: Motor Forense (preview grátis + detalhada paga) ── */}

--- a/frontend/src/pages/PoliticoPage.jsx
+++ b/frontend/src/pages/PoliticoPage.jsx
@@ -26,7 +26,7 @@ import {
   mergeDeputadoRankingOrg,
   RANKING_ORG_PAGE,
 } from "../utils/rankingOrg";
-import { anosCeapLegislaturaAtual } from "../utils/legislatura";
+import { anosCeapHistoricoCompleto } from "../utils/legislatura";
 
 function fmtMoney(value) {
   const n = parseCamaraValorReais(value ?? 0);
@@ -137,7 +137,7 @@ export default function PoliticoPage() {
   const [loading, setLoading] = useState(true);
   const [auditError, setAuditError] = useState("");
   const [pageError, setPageError] = useState("");
-  const [ceapAnos, setCeapAnos] = useState(() => anosCeapLegislaturaAtual());
+  const [ceapAnos, setCeapAnos] = useState(() => anosCeapHistoricoCompleto());
   const [atividadeData, setAtividadeData] = useState(null);
   const CEAP_LIST_MAX = 80;
 
@@ -190,7 +190,7 @@ export default function PoliticoPage() {
         } catch {/* seed / Firestore opcional */}
         if (isMounted) setPol(politico);
 
-        const anosCeap = anosCeapLegislaturaAtual();
+        const anosCeap = anosCeapHistoricoCompleto();
         const nomeBusca = String(politico.nome || politico.nomeCompleto || data?.nome || "").trim();
         const idCamaraBusca = politico.idCamara != null ? Number(politico.idCamara) : null;
         const promises = [];

--- a/frontend/src/utils/legislatura.js
+++ b/frontend/src/utils/legislatura.js
@@ -4,10 +4,21 @@
  */
 export const LEGISLATURA_ATUAL_INICIO_ANO = 2023;
 
+/** Ano inicial para histórico completo de CEAP (API Câmara por ano civil) */
+export const CEAP_HISTORICO_ANO_INICIO = 2019;
+
 /** Anos civis para agregar CEAP da legislatura até o ano corrente */
 export function anosCeapLegislaturaAtual() {
   const y = new Date().getFullYear();
   const out = [];
   for (let a = y; a >= LEGISLATURA_ATUAL_INICIO_ANO; a--) out.push(a);
+  return out;
+}
+
+/** Todos os anos desde 2019 até o ano atual (inclusivo) — soma CEAP multi-mandato */
+export function anosCeapHistoricoCompleto() {
+  const y = new Date().getFullYear();
+  const out = [];
+  for (let a = y; a >= CEAP_HISTORICO_ANO_INICIO; a--) out.push(a);
   return out;
 }

--- a/functions/index.js
+++ b/functions/index.js
@@ -609,10 +609,13 @@ function parseCamaraValorReais(raw) {
   return n;
 }
 
-/** Anos civis da legislatura atual (57ª: 2023–2026) para CEAP — inclui ano corrente */
+/** Anos CEAP quando o cliente não envia lista: 2019 → ano atual (cota por ano civil na API da Câmara) */
 function defaultCeapAnos() {
   const y = new Date().getFullYear();
-  return [y, y - 1, y - 2, y - 3].filter((a) => a >= 2023 && a <= y);
+  const minY = 2019;
+  const out = [];
+  for (let a = y; a >= minY; a--) out.push(a);
+  return out;
 }
 
 async function fetchDespesasAno(deputadoId, ano, maxPages = 12) {
@@ -801,21 +804,26 @@ exports.getEmendasParlamentar = onCall(OPTS, async (req) => {
     return yNext >= yPrev ? next : prev;
   }
 
-  try {
+  async function ingestAnos(queryFn) {
     for (const ano of anos) {
-      let chunk = [];
-      if (codigoAutor) {
-        chunk = await portalFetchEmendasPorAno(ano, `codigoAutor=${encodeURIComponent(codigoAutor)}`);
-      }
-      if (chunk.length === 0 && nomeQuery) {
-        chunk = await portalFetchEmendasPorAno(ano, `nomeAutor=${encodeURIComponent(nomeQuery)}`);
-      }
+      const chunk = await portalFetchEmendasPorAno(ano, queryFn(ano));
       for (const e of chunk) {
         const cod = e?.codigoEmenda;
         if (!cod) continue;
         byCodigo.set(cod, mergeEmendaRow(byCodigo.get(cod), e));
       }
       await sleepMs(400);
+    }
+  }
+
+  try {
+    if (codigoAutor) {
+      await ingestAnos(() => `codigoAutor=${encodeURIComponent(codigoAutor)}`);
+    }
+    // id Câmara ≠ codigoAutor do Portal — se vier vazio, repetir com nome normalizado
+    if (byCodigo.size === 0 && nomeQuery) {
+      byCodigo.clear();
+      await ingestAnos(() => `nomeAutor=${encodeURIComponent(nomeQuery)}`);
     }
 
     const emendas = [...byCodigo.values()].map((raw) => {
@@ -1050,21 +1058,25 @@ exports.getEmendasMapaPontos = onCall(OPTS, async (req) => {
     return coords;
   }
 
-  try {
+  async function ingestMapaAnos(queryFn) {
     for (const ano of anos) {
-      let chunk = [];
-      if (codigoAutor) {
-        chunk = await portalFetchEmendasPorAno(ano, `codigoAutor=${encodeURIComponent(codigoAutor)}`);
-      }
-      if (chunk.length === 0 && nomeQuery) {
-        chunk = await portalFetchEmendasPorAno(ano, `nomeAutor=${encodeURIComponent(nomeQuery)}`);
-      }
+      const chunk = await portalFetchEmendasPorAno(ano, queryFn(ano));
       for (const e of chunk) {
         const cod = e?.codigoEmenda;
         if (!cod) continue;
         byCodigo.set(cod, mergeEmendaRow(byCodigo.get(cod), e));
       }
       await sleepMs(400);
+    }
+  }
+
+  try {
+    if (codigoAutor) {
+      await ingestMapaAnos(() => `codigoAutor=${encodeURIComponent(codigoAutor)}`);
+    }
+    if (byCodigo.size === 0 && nomeQuery) {
+      byCodigo.clear();
+      await ingestMapaAnos(() => `nomeAutor=${encodeURIComponent(nomeQuery)}`);
     }
 
     const rows = [...byCodigo.values()].map((raw) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Dossiê (`DossiePage`)**: passa a buscar CEAP uma vez com `getAuditoriaPolitico` e `anosCeapHistoricoCompleto()` (2019 → ano atual). O total acumulado e o rótulo de período alimentam o KPI do topo, o bloco “Monitor de Gastos CEAP” e a aba **Desempenho**.
- **`PerformanceTab`**: o `GastosMonitor` estava recebendo props erradas (`gastos`/`limite` em vez de `metrics`/`loading`); agora usa as despesas normalizadas vindas do pai e exibe **% vs teto anual do último ano com dados** e **% vs teto acumulado estimado** coerente com o período. `computeCeapTetoMetrics` foi exportado para reutilização.
- **Emendas (Bug 2)**: `getEmendasParlamentar` e `getEmendasMapaPontos` no backend passam a tentar **todo** o ingest por `codigoAutor` e, se não houver linhas, **limpam e repetem** com `nomeAutor` (id da Câmara ≠ código do Portal). No frontend, o dossiê pede emendas/mapa com o intervalo histórico completo; `EmendasAba` atualiza o texto dos anos.
- **`PoliticoPage` + `defaultCeapAnos`**: alinhados ao histórico desde 2019 (evita CEAP só da legislatura atual).

## Testes

- `npm run build` (frontend) — OK.

## Deploy

Após merge, fazer deploy das Cloud Functions alteradas (`getEmendasParlamentar`, `getEmendasMapaPontos`, e qualquer função que dependa de `defaultCeapAnos` se aplicável) e garantir o secret `PORTAL_TRANSPARENCIA_API_KEY` ligado ao runtime Gen 2.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a104e531-5741-475b-a073-18bba97d95ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a104e531-5741-475b-a073-18bba97d95ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

