### PR TITLE
fix: allow DossiePage render for unauthenticated visitors

### DIFF
--- a/frontend/src/pages/DossiePage.jsx
+++ b/frontend/src/pages/DossiePage.jsx
@@ -1070,10 +1070,8 @@ export default function DossiePage() {
     return () => window.removeEventListener("scroll", onScroll);
   }, []);
 
-  // ── Redirect se não autenticado ───────────────────────────────────────────
-  useEffect(() => {
-    if (!user && credits !== null) navigate("/", { replace: true });
-  }, [user, credits, navigate]);
+  // Seções 1-3 (Identidade, CEAP, Diários) são gratuitas e visíveis sem login.
+  // Seção 4 (Laboratório Oráculo) é gated pelo CreditGate.
 
   // ── Verificar desbloqueio (session → Firestore) ───────────────────────────
   useEffect(() => {
@@ -1413,8 +1411,6 @@ export default function DossiePage() {
   }, [politico]);
 
   // ── Estados de UI ─────────────────────────────────────────────────────────
-  if (!user) return null;
-
   if (dataLoading) return (
     <div style={{ minHeight: "100vh", paddingTop: 24 }}>
       <PageSkeleton />


### PR DESCRIPTION
## Problema
A DossiePage (/dossie/:id) mostrava tela totalmente em branco para visitantes não logados. Duas linhas no componente bloqueavam o render:

1. **useEffect redirect** (antiga linha 1073-1075): redirecionava para / se !user
2. **Guard de render** (antiga linha 1416): `if (!user) return null` retornava vazio

## Fix
- Removido o useEffect de redirect forçado
- Removido o guard `if (!user) return null`
- Seções 1-3 (Identidade, CEAP, Diários) agora visíveis sem login
- Seção 4 (Laboratório Oráculo) continua protegida pelo CreditGate
- Cloud Functions de emendas continuam exigindo auth — visitante anônimo vê emendas zeradas (esperado)

## Teste
- Build compila sem erros
- /dossie/204536 sem login deve mostrar perfil do deputado