### PR TITLE
fix(credits): desbloqueio — rules historico ts + dossies merge

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -151,6 +151,7 @@ service cloud.firestore {
       // ── Subcoleção: historico_creditos/{id} (consumo via cliente) ────────
       match /historico_creditos/{histId} {
         allow read: if isOwner(uid) || isAdmin();
+        // ts: serverTimestamp() do cliente avalia como null nas rules — não exigir == request.time
         allow create: if isOwner(uid)
             && request.resource.data.keys().hasOnly(['tipo', 'valor', 'descricao', 'ts'])
             && request.resource.data.tipo == 'uso'
@@ -159,7 +160,7 @@ service cloud.firestore {
             && request.resource.data.valor >= -500
             && request.resource.data.descricao is string
             && request.resource.data.descricao.size() <= 500
-            && request.resource.data.ts == request.time;
+            && (request.resource.data.ts == null || request.resource.data.ts == request.time);
         allow update, delete: if false;
       }
 
@@ -173,9 +174,10 @@ service cloud.firestore {
         // Criado em DossiePage.jsx após deductCredits() confirmar débito
         allow create: if isOwner(uid) && isValidDossieCreate();
 
-        // Update/delete proibidos: a compra é permanente e imutável
-        allow update: if false;
-        allow delete:  if false;
+        // setDoc(..., { merge: true }) em doc existente = update — precisa da mesma validação
+        allow update: if isOwner(uid) && isValidDossieCreate();
+
+        allow delete: if false;
       }
     }
 

--- a/frontend/src/components/CreditGate.jsx
+++ b/frontend/src/components/CreditGate.jsx
@@ -46,13 +46,19 @@ export function CreditGate({ custo, descricao, children, onDesbloqueado }) {
       setDesbloqueado(true);
       onDesbloqueado?.();
     } catch (e) {
-      const msg = e?.message || "Não foi possível desbloquear.";
+      const msg = String(e?.message || "");
+      const code = e?.code;
       if (msg.includes("boas-vindas") || msg.includes("Bem-vindo")) {
         setErro("🎉 " + msg);
-      } else if (/permission|insufficient/i.test(msg) || e?.code === "permission-denied") {
+      } else if (
+        /permission/i.test(msg)
+        || code === "permission-denied"
+      ) {
         setErro("Erro de acesso. Recarregue a página e tente novamente.");
+      } else if (/saldo|crédito|credito|insuf/i.test(msg)) {
+        setErro("Créditos insuficientes. Adquira mais créditos para continuar.");
       } else {
-        setErro(msg);
+        setErro(msg || "Erro ao desbloquear. Tente novamente.");
       }
     } finally {
       setLoading(false);

--- a/frontend/src/hooks/useCreditSystem.js
+++ b/frontend/src/hooks/useCreditSystem.js
@@ -16,15 +16,15 @@ export function useCreditSystem() {
   const checkCredits = useCallback(
     async (custo) => {
       if (!user) return false;
+      if (isAdminFromAuth === true) return true;
       try {
         const snap = await getDoc(doc(db, "usuarios", user.uid));
         if (!snap.exists()) return true;
         const data = snap.data();
         if (usuarioCreditosIlimitados(data)) return true;
-        if (isAdminFromAuth === true) return true;
         return userHasEnoughCredits(db, user.uid, custo);
       } catch (err) {
-        console.error("checkCredits fail-open (transação é a barreira real):", err);
+        console.error("checkCredits error", err);
         return true;
       }
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problema
Transação de débito (`spendUserCredits`) podia falhar por **regras do Firestore**:
- `historico_creditos`: `ts == request.time` incompatível com `serverTimestamp()` (avalia como `null` nas rules).
- `dossies_desbloqueados`: `setDoc(..., { merge: true })` em documento existente = **update**, que estava negado.

## Alterações
- **firestore.rules**: aceitar `ts == null` no create de histórico; permitir `update` em `dossies_desbloqueados` com a mesma validação de create.
- **useCreditSystem.js**: admin primeiro; fail-open em erro de leitura; log `checkCredits error`.
- **CreditGate.jsx**: mensagens distintas para permissão vs saldo.

## Deploy obrigatório
`firebase deploy --only firestore:rules` (e hosting se publicar o bundle novo).

## Teste
`npm run build` OK.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a104e531-5741-475b-a073-18bba97d95ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a104e531-5741-475b-a073-18bba97d95ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

