### PR TITLE
fix(ci): Firebase Vite env no build, SQLSERVER no deploy das functions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,13 @@ jobs:
       - name: Build React app
         run: npm run build
         working-directory: frontend
+        env:
+          VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
+          VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
+          VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+          VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}
+          VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
+          VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
 
       - name: Install Firebase CLI
         run: npm install -g firebase-tools
@@ -47,11 +54,8 @@ jobs:
 
       - name: Create .env for Functions
         run: |
-          echo "DB_HOST=${{ secrets.DB_HOST }}" > .env
-          echo "DB_USER=${{ secrets.DB_USER }}" >> .env
-          echo "DB_PASS=${{ secrets.DB_PASS }}" >> .env
-          echo "DB_NAME=${{ secrets.DB_NAME }}" >> .env
-          echo "PORTAL_TRANSPARENCIA_API_KEY=${{ secrets.PORTAL_TRANSPARENCIA_API_KEY }}" >> .env
+          echo "PORTAL_TRANSPARENCIA_API_KEY=${{ secrets.PORTAL_TRANSPARENCIA_API_KEY }}" > .env
+          echo "SQLSERVER=${{ secrets.SQLSERVER }}" >> .env
         working-directory: functions
 
       - name: Deploy Functions + Firestore rules

--- a/frontend/src/lib/firebase.js
+++ b/frontend/src/lib/firebase.js
@@ -4,12 +4,12 @@ import { getFirestore } from "firebase/firestore";
 import { getFunctions } from "firebase/functions";
 
 const firebaseConfig = {
-  apiKey: "AIzaSyDuII-aOUbsrVv3H-Qb_0XSe1XLV97Da24",
-  authDomain: "fiscallizapa.firebaseapp.com",
-  projectId: "fiscallizapa",
-  storageBucket: "fiscallizapa.firebasestorage.app",
-  messagingSenderId: "993207283220",
-  appId: "1:993207283220:web:b58b551b41104a3ada0101",
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
+  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+  appId: import.meta.env.VITE_FIREBASE_APP_ID,
 };
 
 const app = initializeApp(firebaseConfig);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## O que mudou

- **`frontend/src/lib/firebase.js`**: config passa a usar `import.meta.env.VITE_FIREBASE_*` (valores locais via `frontend/.env.local`, ignorado pelo git).
- **`.github/workflows/deploy.yml`**:
  - Step **Build React app** exporta `VITE_FIREBASE_*` a partir dos **GitHub Secrets** (necessário para o CI; `.env.local` não vai para o repositório).
  - **Create .env for Functions** usa só `PORTAL_TRANSPARENCIA_API_KEY` e `SQLSERVER` (remove `DB_HOST`/`DB_USER`/`DB_PASS`/`DB_NAME`).

## Ação necessária no repositório

Criar estes secrets em **Settings → Secrets and variables → Actions** (valores iguais ao teu `.env.local` / Firebase Console):

- `VITE_FIREBASE_API_KEY`
- `VITE_FIREBASE_AUTH_DOMAIN`
- `VITE_FIREBASE_PROJECT_ID`
- `VITE_FIREBASE_STORAGE_BUCKET`
- `VITE_FIREBASE_MESSAGING_SENDER_ID`
- `VITE_FIREBASE_APP_ID`

Já devem existir: `FIREBASE_SERVICE_ACCOUNT`, `PORTAL_TRANSPARENCIA_API_KEY`, `SQLSERVER`.

## Nota

`functions/` não referencia `DB_*` nem `SQLSERVER` no código atual; o `.env` no CI serve para deploy/runtime alinhado ao secret existente.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a104e531-5741-475b-a073-18bba97d95ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a104e531-5741-475b-a073-18bba97d95ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

