### PR TITLE
fix(auth): OAuth redirect — ensureUserDoc + LoginPage espera loading

### DIFF
--- a/frontend/src/hooks/useAuth.js
+++ b/frontend/src/hooks/useAuth.js
@@ -96,14 +96,23 @@ export function useAuth() {
   });
 
   // ── Processar resultado do redirect (Google / GitHub) ─────────────────────
-  // Roda UMA vez ao montar — captura o resultado após o redirect OAuth.
+  // Roda UMA vez ao montar — captura o resultado após o redirect OAuth e provisiona Firestore cedo.
   useEffect(() => {
-    getRedirectResult(auth).catch((err) => {
-      // Erros esperados: popup_closed_by_user, cancelled — silenciar.
-      if (!err?.code?.includes("cancelled") && !err?.code?.includes("popup-closed")) {
-        console.warn("getRedirectResult error:", err.code, err.message);
-      }
-    });
+    getRedirectResult(auth)
+      .then(async (result) => {
+        if (result?.user) {
+          try {
+            await ensureUserDoc(result.user);
+          } catch {
+            /* onAuthStateChanged também chama ensureUserDoc */
+          }
+        }
+      })
+      .catch((err) => {
+        if (!err?.code?.includes("cancelled") && !err?.code?.includes("popup-closed")) {
+          console.warn("getRedirectResult error:", err.code, err.message);
+        }
+      });
   }, []);
 
   // ── Listener de autenticação ──────────────────────────────────────────────

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -7,7 +7,7 @@ import LoginModal from "../components/LoginModal";
 export default function LoginPage() {
   const navigate = useNavigate();
   const location = useLocation();
-  const { user, login, loginWithGitHub, loginWithEmail, registerWithEmail } = useAuth();
+  const { user, loading, login, loginWithGitHub, loginWithEmail, registerWithEmail } = useAuth();
   const [showModal, setShowModal] = useState(true);
 
   const from =
@@ -16,11 +16,10 @@ export default function LoginPage() {
     "/ranking";
 
   useEffect(() => {
-    if (user) {
-      const dest = typeof from === "string" && from.startsWith("/") ? from : "/ranking";
-      navigate(dest, { replace: true });
-    }
-  }, [user, from, navigate]);
+    if (loading || !user) return;
+    const dest = typeof from === "string" && from.startsWith("/") ? from : "/ranking";
+    navigate(dest, { replace: true });
+  }, [user, loading, from, navigate]);
 
   return (
     <div


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problema
Após `signInWithRedirect`, o retorno caía em `/login` e a UI podia redirecionar antes do estado de auth estabilizar.

## Mudanças
- **`useAuth.js`**: `getRedirectResult` agora, quando há `result.user`, chama `await ensureUserDoc(result.user)` antes da corrida com o render da LoginPage (mantém `signInWithRedirect` já presente no `main`).
- **`LoginPage.jsx`**: redirecionamento pós-login só quando `!loading && user`, evitando navegar com `user` ainda `null` no primeiro paint após o redirect.

Build `npm run build` OK.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a104e531-5741-475b-a073-18bba97d95ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a104e531-5741-475b-a073-18bba97d95ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

