### PR TITLE
fix(home): tbr_auth_redirect para OAuth da home e pós-login [MERGED MANUALLY TO MAIN]

### DIFF
--- a/frontend/src/hooks/useAuth.js
+++ b/frontend/src/hooks/useAuth.js
@@ -96,14 +96,23 @@ export function useAuth() {
   });
 
   // ── Processar resultado do redirect (Google / GitHub) ─────────────────────
-  // Roda UMA vez ao montar — captura o resultado após o redirect OAuth.
+  // Roda UMA vez ao montar — captura o resultado após o redirect OAuth e provisiona Firestore cedo.
   useEffect(() => {
-    getRedirectResult(auth).catch((err) => {
-      // Erros esperados: popup_closed_by_user, cancelled — silenciar.
-      if (!err?.code?.includes("cancelled") && !err?.code?.includes("popup-closed")) {
-        console.warn("getRedirectResult error:", err.code, err.message);
-      }
-    });
+    getRedirectResult(auth)
+      .then(async (result) => {
+        if (result?.user) {
+          try {
+            await ensureUserDoc(result.user);
+          } catch {
+            /* onAuthStateChanged também chama ensureUserDoc */
+          }
+        }
+      })
+      .catch((err) => {
+        if (!err?.code?.includes("cancelled") && !err?.code?.includes("popup-closed")) {
+          console.warn("getRedirectResult error:", err.code, err.message);
+        }
+      });
   }, []);
 
   // ── Listener de autenticação ──────────────────────────────────────────────
@@ -230,8 +239,19 @@ export function useAuth() {
   // ─── Ações de autenticação ────────────────────────────────────────────────
   // signInWithRedirect: compatível com domínios customizados e browsers que
   // bloqueiam popups (Chrome, Safari em mobile, etc).
-  const login           = () => signInWithRedirect(auth, googleProvider);
-  const loginWithGitHub = () => signInWithRedirect(auth, githubProvider);
+  // redirectAfter: caminho interno salvo em sessionStorage (tbr_auth_redirect) para pós-login.
+  const login = (redirectAfter) => {
+    try {
+      if (redirectAfter) sessionStorage.setItem("tbr_auth_redirect", redirectAfter);
+    } catch { /* noop */ }
+    return signInWithRedirect(auth, googleProvider);
+  };
+  const loginWithGitHub = (redirectAfter) => {
+    try {
+      if (redirectAfter) sessionStorage.setItem("tbr_auth_redirect", redirectAfter);
+    } catch { /* noop */ }
+    return signInWithRedirect(auth, githubProvider);
+  };
   const loginWithEmail  = (email, password) => signInWithEmailAndPassword(auth, email, password);
 
   const registerWithEmail = async (email, password) => {

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -185,6 +185,17 @@ export default function HomePage({ user, login, loginWithGitHub, loginWithEmail,
     fetchRanking();
   }, []);
 
+  useEffect(() => {
+    if (!user) return;
+    try {
+      const saved = sessionStorage.getItem("tbr_auth_redirect");
+      if (saved && saved.startsWith("/") && saved !== "/login") {
+        sessionStorage.removeItem("tbr_auth_redirect");
+        // não redireciona da home — o usuário já está onde quer
+      }
+    } catch { /* noop */ }
+  }, [user]);
+
   const gradientTotal = totalDeputados;
 
   const handleEmailSubmit = async (e) => {
@@ -334,8 +345,32 @@ export default function HomePage({ user, login, loginWithGitHub, loginWithEmail,
             )}
             {authMode === 'choose' ? (
               <>
-                <button onClick={async () => { setAuthError(''); try { await login(); } catch(e) { setAuthError(e.message); } }} style={btn('#1B5E3B')}>Entrar com Google</button>
-                <button onClick={async () => { setAuthError(''); try { await loginWithGitHub(); } catch(e) { setAuthError(e.message); } }} style={btn('#24292E')}>Entrar com GitHub</button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setAuthError("");
+                    try {
+                      sessionStorage.setItem("tbr_auth_redirect", "/");
+                    } catch { /* noop */ }
+                    login();
+                  }}
+                  style={btn("#1B5E3B")}
+                >
+                  Entrar com Google
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setAuthError("");
+                    try {
+                      sessionStorage.setItem("tbr_auth_redirect", "/");
+                    } catch { /* noop */ }
+                    loginWithGitHub();
+                  }}
+                  style={btn("#24292E")}
+                >
+                  Entrar com GitHub
+                </button>
                 <div style={{ display: 'flex', alignItems: 'center', gap: 8, margin: '14px 0' }}>
                   <div style={{ flex: 1, height: 1, background: '#EDEBE8' }} />
                   <span style={{ fontSize: 12, color: '#AAA' }}>ou</span>

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -7,7 +7,7 @@ import LoginModal from "../components/LoginModal";
 export default function LoginPage() {
   const navigate = useNavigate();
   const location = useLocation();
-  const { user, login, loginWithGitHub, loginWithEmail, registerWithEmail } = useAuth();
+  const { user, loading, login, loginWithGitHub, loginWithEmail, registerWithEmail } = useAuth();
   const [showModal, setShowModal] = useState(true);
 
   const from =
@@ -16,11 +16,24 @@ export default function LoginPage() {
     "/ranking";
 
   useEffect(() => {
-    if (user) {
-      const dest = typeof from === "string" && from.startsWith("/") ? from : "/ranking";
-      navigate(dest, { replace: true });
+    if (loading || !user) return;
+    let dest = "/ranking";
+    try {
+      const saved = sessionStorage.getItem("tbr_auth_redirect");
+      if (saved && saved.startsWith("/") && saved !== "/login") {
+        dest = saved;
+        sessionStorage.removeItem("tbr_auth_redirect");
+      } else if (typeof from === "string" && from.startsWith("/") && from !== "/login") {
+        dest = from;
+      }
+    } catch {
+      dest =
+        typeof from === "string" && from.startsWith("/") && from !== "/login"
+          ? from
+          : "/ranking";
     }
-  }, [user, from, navigate]);
+    navigate(dest, { replace: true });
+  }, [user, loading, from, navigate]);
 
   return (
     <div
@@ -49,8 +62,20 @@ export default function LoginPage() {
       {showModal && (
         <LoginModal
           onClose={() => setShowModal(false)}
-          onGoogle={login}
-          onGitHub={loginWithGitHub}
+          onGoogle={() => {
+            const dest =
+              typeof from === "string" && from.startsWith("/") && from !== "/login"
+                ? from
+                : "/ranking";
+            login(dest);
+          }}
+          onGitHub={() => {
+            const dest =
+              typeof from === "string" && from.startsWith("/") && from !== "/login"
+                ? from
+                : "/ranking";
+            loginWithGitHub(dest);
+          }}
           onEmail={loginWithEmail}
           onRegister={registerWithEmail}
         />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## O que mudou

- **`HomePage`**: antes de `login()` / `loginWithGitHub()`, grava `sessionStorage.setItem('tbr_auth_redirect', '/')`. `useEffect` com `user` limpa a chave quando o utilizador volta autenticado (evita redirect desnecessário na própria home).
- **`useAuth`**: `login(redirectAfter)` e `loginWithGitHub(redirectAfter)` só gravam `tbr_auth_redirect` quando recebem argumento (não sobrescreve o que a home já definiu). Mantido `getRedirectResult` + `ensureUserDoc` após OAuth.
- **`LoginPage`**: redirecionamento após login prioriza `tbr_auth_redirect`, depois `from` (router), default `/ranking`; só navega com `!loading && user`. OAuth no modal chama `login(dest)` / `loginWithGitHub(dest)` com o destino derivado de `from`.

Fluxo esperado: OAuth na home → volta a `/login` → redirect para `/`. `/dashboard` → login → OAuth → `/dashboard`.

Build: `npm run build` OK.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a104e531-5741-475b-a073-18bba97d95ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a104e531-5741-475b-a073-18bba97d95ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

