### PR TITLE
fix(dossie): getDoc por ID em deputados_federais, API Câmara e enrich script

### DIFF
--- a/engines/scripts/run-ingest-emendas-v4.js
+++ b/engines/scripts/run-ingest-emendas-v4.js
@@ -26,6 +26,41 @@ const IDH_UF = {
 
 const sleep = ms => new Promise(r => setTimeout(r, ms));
 
+const CAMARA_DEP = id => `https://dadosabertos.camara.leg.br/api/v2/deputados/${id}`;
+
+async function fetchCamaraIdentity(depId) {
+  try {
+    const res = await fetch(CAMARA_DEP(depId));
+    if (!res.ok) return null;
+    const json = await res.json();
+    const d = json?.dados;
+    if (!d) return null;
+    const us = d.ultimoStatus || {};
+    const idC = d.id != null ? parseInt(String(d.id), 10) : NaN;
+    let urlFoto = us.urlFoto || d.urlFoto || "";
+    if (urlFoto && !/^https?:\/\//i.test(urlFoto)) {
+      urlFoto = urlFoto.startsWith("//") ? `https:${urlFoto}` : `https://www.camara.leg.br${urlFoto.startsWith("/") ? "" : "/"}${urlFoto}`;
+    }
+    if (!urlFoto && Number.isFinite(idC)) {
+      urlFoto = `https://www.camara.leg.br/img/deputados/med/${idC}.jpg`;
+    }
+    return {
+      idCamara: Number.isFinite(idC) ? idC : null,
+      nome: (us.nomeEleitoral || d.nome || "").trim() || null,
+      nomeCompleto: (d.nome || "").trim() || null,
+      nomeCivil: (d.nomeCivil || "").trim() || null,
+      cpf: d.cpf != null ? String(d.cpf) : "",
+      siglaPartido: (us.siglaPartido || d.siglaPartido || "").trim() || null,
+      partido: (us.siglaPartido || d.siglaPartido || "").trim() || null,
+      uf: (us.siglaUf || d.siglaUf || "").trim() || null,
+      urlFoto: urlFoto || null,
+      ultimoStatus: { ...us, urlFoto: us.urlFoto || d.urlFoto },
+    };
+  } catch {
+    return null;
+  }
+}
+
 function normalize(name) {
   return name.toUpperCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '');
 }
@@ -96,8 +131,23 @@ async function main() {
   console.log(`Pedro Paulo mixed: ${t2.length} results`);
 
   const snap = await db.collection("deputados_federais").get();
-  const deps = snap.docs.map(d => ({ id: d.id, ...d.data() })).filter(d => d.nome);
-  console.log(`\n${deps.length} deputados federais.`);
+  const deps = [];
+  for (const d of snap.docs) {
+    let row = { id: d.id, ...d.data() };
+    const hasNome = row.nome || row.nomeCompleto;
+    const hasPartido = row.siglaPartido || row.partido;
+    const hasFoto = row.urlFoto || row?.ultimoStatus?.urlFoto;
+    if (!hasNome || !hasPartido || !hasFoto) {
+      const iden = await fetchCamaraIdentity(d.id);
+      await sleep(200);
+      if (iden && iden.nome) {
+        await d.ref.set(iden, { merge: true });
+        row = { ...row, ...iden };
+      }
+    }
+    if (row.nome || row.nomeCompleto) deps.push(row);
+  }
+  console.log(`\n${deps.length} deputados federais (com nome).`);
   console.log(`First 3: ${deps.slice(0,3).map(d => `${d.nome} -> ${normalize(d.nome)}`).join('; ')}`);
 
   const anos = [2023, 2024, 2025];

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,15 @@
+# Copie para .env.local e preencha (não commitar segredos).
+
+# Firebase — Console do projeto ou configuração web
+VITE_FIREBASE_API_KEY=
+VITE_FIREBASE_AUTH_DOMAIN=
+VITE_FIREBASE_PROJECT_ID=
+VITE_FIREBASE_STORAGE_BUCKET=
+VITE_FIREBASE_MESSAGING_SENDER_ID=
+VITE_FIREBASE_APP_ID=
+
+# Portal da Transparência — mesma chave que nas Cloud Functions (PORTAL_TRANSPARENCIA_API_KEY). Obter em https://api.portaldatransparencia.gov.br/
+VITE_PORTAL_TRANSPARENCIA_KEY=
+
+# Mapbox — https://account.mapbox.com/ (opcional; mapas que usarem token)
+VITE_MAPBOX_TOKEN=

--- a/frontend/src/pages/DossiePage.jsx
+++ b/frontend/src/pages/DossiePage.jsx
@@ -95,6 +95,70 @@ function sessionKey(id, tipo = "full") {
   return `dossie_${tipo}_${id}`;
 }
 
+/** JSON da API GET /deputados/{id} → campos usados na UI */
+async function fetchCamaraDeputadoJson(idCamara) {
+  const n = Number(idCamara);
+  if (!Number.isFinite(n)) return null;
+  try {
+    const res = await fetch(
+      `https://dadosabertos.camara.leg.br/api/v2/deputados/${n}`,
+    );
+    if (!res.ok) return null;
+    const json = await res.json();
+    return json?.dados ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Mescla identidade da API da Câmara (ultimoStatus) em objeto político */
+function applyCamaraIdentityFromDados(d) {
+  if (!d) return {};
+  const us = d.ultimoStatus || {};
+  const idC = d.id != null ? Number(d.id) : NaN;
+  const nome = (us.nomeEleitoral || d.nome || d.nomeCivil || "").trim();
+  const siglaPartido = (us.siglaPartido || d.siglaPartido || "").trim();
+  const uf = (us.siglaUf || d.siglaUf || d.uf || "").trim();
+  let urlFoto = absolutizeCamaraUrl(us.urlFoto || d.urlFoto || "");
+  if (!urlFoto && Number.isFinite(idC)) {
+    urlFoto = `https://www.camara.leg.br/img/deputados/med/${idC}.jpg`;
+  }
+  return {
+    nome: nome || undefined,
+    nomeCompleto: d.nome || nome || undefined,
+    nomeCivil: d.nomeCivil || "",
+    cpf: d.cpf || "",
+    siglaPartido: siglaPartido || undefined,
+    partido: siglaPartido || undefined,
+    uf: uf || undefined,
+    idCamara: Number.isFinite(idC) ? idC : undefined,
+    urlFoto,
+    ultimoStatus: {
+      ...us,
+      nomeEleitoral: us.nomeEleitoral,
+      siglaPartido,
+      siglaUf: uf,
+      urlFoto: us.urlFoto || d.urlFoto,
+    },
+    situacao: us.situacao || d.situacao || "",
+    email: d.email || us.email || "",
+    gabinete: us.gabinete ?? d.gabinete,
+    municipioNascimento: d.municipioNascimento || "",
+    ufNascimento: d.ufNascimento || "",
+    dataNascimento: d.dataNascimento || "",
+    escolaridade: d.escolaridade || "",
+    sexo: d.sexo || "",
+  };
+}
+
+function needsIdentityEnrichment(pol) {
+  if (!pol) return true;
+  const nome = pol.nome || pol.nomeCompleto;
+  const partido = pol.siglaPartido || pol.partido;
+  const foto = pol.urlFoto || pol?.ultimoStatus?.urlFoto;
+  return !nome || !partido || !foto;
+}
+
 // ─── SEV config ────────────────────────────────────────────────────────────────
 const SEV = {
   ALTA:  { label: "Alto Risco", color: "#C82538", bg: "rgba(200,37,56,0.08)"  },
@@ -1160,43 +1224,82 @@ export default function DossiePage() {
     async function loadData() {
       setDataLoading(true);
       try {
-        const isNumericId = /^\d+$/.test(String(id));
+        const sid = String(id);
+        const isNumericRoute = /^\d+$/.test(sid);
         let pol = null;
         let allowPoliticosPhotoWrite = false;
 
-        if (isNumericId) {
-          const idCamaraNum = Number(id);
-          const pq = query(collection(db, "politicos"), where("idCamara", "==", idCamaraNum), limit(1));
-          const pr = await getDocs(pq);
-          if (pr.docs[0]) {
-            const d = pr.docs[0];
-            if (!cancelled) {
-              navigate(`/dossie/${d.id}`, { replace: true });
-            }
-            return;
-          }
-          const dq = query(collection(db, "deputados_federais"), where("idCamara", "==", idCamaraNum), limit(1));
-          const dr = await getDocs(dq);
-          if (!dr.docs[0]) {
-            if (!cancelled) setNotFound(true);
-            return;
-          }
-          pol = { id: dr.docs[0].id, ...dr.docs[0].data() };
-          if (!cancelled) setRealDocId(dr.docs[0].id);
+        const legFirst = await getDoc(doc(db, "deputados_federais", sid));
+        if (legFirst.exists()) {
+          pol = { id: legFirst.id, ...legFirst.data() };
+          if (!cancelled) setRealDocId(legFirst.id);
         } else {
-          const pSnap = await getDoc(doc(db, "politicos", id));
-          if (pSnap.exists()) {
-            pol = { id: pSnap.id, ...pSnap.data() };
-            if (!cancelled) setRealDocId(pSnap.id);
+          const pFirst = await getDoc(doc(db, "politicos", sid));
+          if (pFirst.exists()) {
+            pol = { id: pFirst.id, ...pFirst.data() };
+            if (!cancelled) setRealDocId(pFirst.id);
             allowPoliticosPhotoWrite = true;
+          }
+        }
+
+        if (!pol && isNumericRoute) {
+          const idCamaraNum = Number(sid);
+          const dq = query(
+            collection(db, "deputados_federais"),
+            where("idCamara", "==", idCamaraNum),
+            limit(1),
+          );
+          const dr = await getDocs(dq);
+          if (dr.docs[0]) {
+            pol = { id: dr.docs[0].id, ...dr.docs[0].data() };
+            if (!cancelled) setRealDocId(dr.docs[0].id);
           } else {
-            const leg = await getDoc(doc(db, "deputados_federais", id));
-            if (!leg.exists()) {
-              if (!cancelled) setNotFound(true);
+            const pq = query(
+              collection(db, "politicos"),
+              where("idCamara", "==", idCamaraNum),
+              limit(1),
+            );
+            const pr = await getDocs(pq);
+            if (pr.docs[0]) {
+              const d = pr.docs[0];
+              if (!cancelled) {
+                navigate(`/dossie/${d.id}`, { replace: true });
+              }
               return;
             }
-            pol = { id: leg.id, ...leg.data() };
-            if (!cancelled) setRealDocId(leg.id);
+          }
+        }
+
+        if (!pol && isNumericRoute) {
+          const camaraDados = await fetchCamaraDeputadoJson(sid);
+          if (camaraDados) {
+            const enriched = applyCamaraIdentityFromDados(camaraDados);
+            pol = {
+              id: sid,
+              ...enriched,
+              fromCamaraOnly: true,
+            };
+            if (!cancelled) setRealDocId(sid);
+          }
+        }
+
+        if (!pol) {
+          if (!cancelled) setNotFound(true);
+          return;
+        }
+
+        if (needsIdentityEnrichment(pol)) {
+          const idApi =
+            pol.idCamara != null && Number.isFinite(Number(pol.idCamara))
+              ? Number(pol.idCamara)
+              : isNumericRoute
+                ? Number(sid)
+                : NaN;
+          if (Number.isFinite(idApi)) {
+            const camaraDados = await fetchCamaraDeputadoJson(idApi);
+            if (camaraDados) {
+              pol = { ...pol, ...applyCamaraIdentityFromDados(camaraDados) };
+            }
           }
         }
 

--- a/frontend/src/pages/DossiePage.jsx
+++ b/frontend/src/pages/DossiePage.jsx
@@ -1244,22 +1244,38 @@ export default function DossiePage() {
 
         if (!pol && isNumericRoute) {
           const idCamaraNum = Number(sid);
-          const dq = query(
+          let dq = query(
             collection(db, "deputados_federais"),
             where("idCamara", "==", idCamaraNum),
             limit(1),
           );
-          const dr = await getDocs(dq);
+          let dr = await getDocs(dq);
+          if (dr.empty) {
+            dq = query(
+              collection(db, "deputados_federais"),
+              where("idCamara", "==", sid),
+              limit(1),
+            );
+            dr = await getDocs(dq);
+          }
           if (dr.docs[0]) {
             pol = { id: dr.docs[0].id, ...dr.docs[0].data() };
             if (!cancelled) setRealDocId(dr.docs[0].id);
           } else {
-            const pq = query(
+            let pq = query(
               collection(db, "politicos"),
               where("idCamara", "==", idCamaraNum),
               limit(1),
             );
-            const pr = await getDocs(pq);
+            let pr = await getDocs(pq);
+            if (pr.empty) {
+              pq = query(
+                collection(db, "politicos"),
+                where("idCamara", "==", sid),
+                limit(1),
+              );
+              pr = await getDocs(pq);
+            }
             if (pr.docs[0]) {
               const d = pr.docs[0];
               if (!cancelled) {

--- a/scripts/enrich-firestore.js
+++ b/scripts/enrich-firestore.js
@@ -1,12 +1,14 @@
 /**
- * Enriquece documentos em deputados_federais com dados de identidade da API
- * Dados Abertos da Câmara (sem chave).
+ * Enriquece `deputados_federais` com dados da API aberta da Câmara (lista paginada + merge).
+ *
+ * Credenciais (qualquer uma):
+ *   gcloud auth application-default login
+ *   export GOOGLE_APPLICATION_CREDENTIALS=/caminho/service-account.json
  *
  * Uso:
- *   export GOOGLE_APPLICATION_CREDENTIALS=/caminho/service-account.json
  *   node scripts/enrich-firestore.js
  *
- * Projeto: fiscallizapa
+ * Projeto Firebase: fiscallizapa
  */
 
 const path = require("path");
@@ -18,110 +20,116 @@ try {
 }
 
 const PROJECT_ID = "fiscallizapa";
-const CAMARA_BASE = "https://dadosabertos.camara.leg.br/api/v2/deputados";
-const SLEEP_MS = 200;
+const CAMARA_LIST = "https://dadosabertos.camara.leg.br/api/v2/deputados";
+const BATCH_SIZE = 400;
+const PAGE_SLEEP_MS = 300;
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 if (!admin.apps.length) {
-  admin.initializeApp({ projectId: PROJECT_ID });
+  admin.initializeApp({
+    credential: admin.credential.applicationDefault(),
+    projectId: PROJECT_ID,
+  });
 }
 
 const db = admin.firestore();
 
-async function fetchDeputado(id) {
-  const res = await fetch(`${CAMARA_BASE}/${id}`);
-  if (!res.ok) return null;
-  const json = await res.json();
-  return json?.dados ?? null;
+function absolutizeFoto(url, idCamara) {
+  let u = String(url || "").trim();
+  if (u && !/^https?:\/\//i.test(u)) {
+    u = u.startsWith("//") ? `https:${u}` : `https://www.camara.leg.br${u.startsWith("/") ? "" : "/"}${u}`;
+  }
+  if (!u && Number.isFinite(idCamara)) {
+    u = `https://www.camara.leg.br/img/deputados/med/${idCamara}.jpg`;
+  }
+  return u || null;
 }
 
-function mapCamaraToFirestore(d) {
-  if (!d) return null;
-  const us = d.ultimoStatus || {};
-  const idC = d.id != null ? parseInt(String(d.id), 10) : NaN;
-  let urlFoto = us.urlFoto || d.urlFoto || "";
-  if (urlFoto && !/^https?:\/\//i.test(urlFoto)) {
-    urlFoto = urlFoto.startsWith("//") ? `https:${urlFoto}` : `https://www.camara.leg.br${urlFoto.startsWith("/") ? "" : "/"}${urlFoto}`;
-  }
-  if (!urlFoto && Number.isFinite(idC)) {
-    urlFoto = `https://www.camara.leg.br/img/deputados/med/${idC}.jpg`;
-  }
+function mapListItem(dep) {
+  const idC = dep.id != null ? parseInt(String(dep.id), 10) : NaN;
+  const nome = (dep.nome || "").trim();
+  const siglaPartido = (dep.siglaPartido || "").trim();
+  const siglaUf = (dep.siglaUf || "").trim();
+  const urlFoto = absolutizeFoto(dep.urlFoto, idC);
   return {
     idCamara: Number.isFinite(idC) ? idC : null,
-    nome: (us.nomeEleitoral || d.nome || "").trim() || null,
-    nomeCompleto: (d.nome || "").trim() || null,
-    nomeCivil: (d.nomeCivil || "").trim() || null,
-    cpf: d.cpf != null ? String(d.cpf) : "",
-    siglaPartido: (us.siglaPartido || d.siglaPartido || "").trim() || null,
-    siglaUf: (us.siglaUf || d.siglaUf || "").trim() || null,
-    urlFoto: urlFoto || null,
-    situacao: (us.situacao || d.situacao || "").trim() || null,
-    email: (d.email || us.email || "").trim() || null,
-    gabinete: us.gabinete ?? d.gabinete ?? null,
-    municipioNascimento: (d.municipioNascimento || "").trim() || null,
-    ufNascimento: (d.ufNascimento || "").trim() || null,
-    dataNascimento: d.dataNascimento || null,
-    escolaridade: (d.escolaridade || "").trim() || null,
-    sexo: (d.sexo || "").trim() || null,
+    nome: nome || null,
+    nomeCompleto: nome || null,
+    siglaPartido: siglaPartido || null,
+    partido: siglaPartido || null,
+    siglaUf: siglaUf || null,
+    uf: siglaUf || null,
+    urlFoto,
+    ultimoStatus: {
+      nomeEleitoral: nome,
+      siglaPartido,
+      siglaUf,
+      urlFoto: dep.urlFoto || null,
+    },
     enrichedAt: admin.firestore.FieldValue.serverTimestamp(),
   };
 }
 
-function hasIdentity(data) {
-  const nome = data.nome || data.nomeCompleto;
-  const partido = data.siglaPartido || data.partido;
-  const foto = data.urlFoto;
-  return Boolean(nome && partido && foto);
+async function fetchAllDeputadosLista() {
+  const all = [];
+  let pagina = 1;
+  for (;;) {
+    const url = `${CAMARA_LIST}?pagina=${pagina}&itens=100&ordem=ASC&ordenarPor=nome`;
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`API Câmara HTTP ${res.status} (página ${pagina})`);
+    }
+    const json = await res.json();
+    const dados = Array.isArray(json.dados) ? json.dados : [];
+    if (!dados.length) break;
+    all.push(...dados);
+    console.log(`  … lista página ${pagina}: +${dados.length} (total ${all.length})`);
+    if (dados.length < 100) break;
+    pagina++;
+    await sleep(PAGE_SLEEP_MS);
+  }
+  return all;
 }
 
 async function main() {
-  console.log(`=== enrich-firestore (${PROJECT_ID}) ===`);
-  const snap = await db.collection("deputados_federais").get();
-  const docs = snap.docs;
-  let i = 0;
-  let updated = 0;
-  let skipped = 0;
+  console.log(`=== enrich-firestore (${PROJECT_ID}) — lista API + merge em deputados_federais ===`);
+  console.log("Credencial: application-default (gcloud auth application-default login) ou GOOGLE_APPLICATION_CREDENTIALS\n");
 
-  for (const docSnap of docs) {
-    i++;
-    const data = docSnap.data() || {};
-    if (hasIdentity(data)) {
-      skipped++;
-      if (i % 10 === 0) {
-        console.log(`[${i}/${docs.length}] progress — updated ${updated}, skipped ${skipped}`);
-      }
-      continue;
-    }
+  const deputados = await fetchAllDeputadosLista();
+  if (!deputados.length) {
+    console.error("Nenhum deputado retornado pela API.");
+    process.exit(1);
+  }
 
-    const depId = docSnap.id;
-    const camara = await fetchDeputado(depId);
-    await sleep(SLEEP_MS);
+  let batch = db.batch();
+  let batchCount = 0;
+  let total = 0;
 
-    if (!camara) {
-      console.warn(`  [${depId}] API sem dados`);
-      if (i % 10 === 0) {
-        console.log(`[${i}/${docs.length}] progress — updated ${updated}, skipped ${skipped}`);
-      }
-      continue;
-    }
+  for (const dep of deputados) {
+    const docId = String(dep.id);
+    const patch = mapListItem(dep);
+    if (!patch.nome) continue;
 
-    const patch = mapCamaraToFirestore(camara);
-    if (!patch || !patch.nome) {
-      console.warn(`  [${depId}] map vazio`);
-      continue;
-    }
+    const ref = db.collection("deputados_federais").doc(docId);
+    batch.set(ref, patch, { merge: true });
+    batchCount++;
+    total++;
 
-    await docSnap.ref.update(patch);
-    updated++;
-    console.log(`  [${depId}] OK — ${patch.nome}`);
-
-    if (i % 10 === 0) {
-      console.log(`[${i}/${docs.length}] progress — updated ${updated}, skipped ${skipped}`);
+    if (batchCount >= BATCH_SIZE) {
+      await batch.commit();
+      console.log(`  commit batch (${total}/${deputados.length})`);
+      batch = db.batch();
+      batchCount = 0;
     }
   }
 
-  console.log(`\nConcluído: ${updated} atualizados, ${skipped} já tinham identidade, ${docs.length} docs no total.`);
+  if (batchCount > 0) {
+    await batch.commit();
+    console.log(`  commit final (${batchCount} docs)`);
+  }
+
+  console.log(`\nConcluído: ${total} documentos mesclados em deputados_federais/{idCamara}.`);
 }
 
 main().catch((e) => {

--- a/scripts/enrich-firestore.js
+++ b/scripts/enrich-firestore.js
@@ -1,0 +1,130 @@
+/**
+ * Enriquece documentos em deputados_federais com dados de identidade da API
+ * Dados Abertos da Câmara (sem chave).
+ *
+ * Uso:
+ *   export GOOGLE_APPLICATION_CREDENTIALS=/caminho/service-account.json
+ *   node scripts/enrich-firestore.js
+ *
+ * Projeto: fiscallizapa
+ */
+
+const path = require("path");
+let admin;
+try {
+  admin = require("firebase-admin");
+} catch {
+  admin = require(path.join(__dirname, "../functions/node_modules/firebase-admin"));
+}
+
+const PROJECT_ID = "fiscallizapa";
+const CAMARA_BASE = "https://dadosabertos.camara.leg.br/api/v2/deputados";
+const SLEEP_MS = 200;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+if (!admin.apps.length) {
+  admin.initializeApp({ projectId: PROJECT_ID });
+}
+
+const db = admin.firestore();
+
+async function fetchDeputado(id) {
+  const res = await fetch(`${CAMARA_BASE}/${id}`);
+  if (!res.ok) return null;
+  const json = await res.json();
+  return json?.dados ?? null;
+}
+
+function mapCamaraToFirestore(d) {
+  if (!d) return null;
+  const us = d.ultimoStatus || {};
+  const idC = d.id != null ? parseInt(String(d.id), 10) : NaN;
+  let urlFoto = us.urlFoto || d.urlFoto || "";
+  if (urlFoto && !/^https?:\/\//i.test(urlFoto)) {
+    urlFoto = urlFoto.startsWith("//") ? `https:${urlFoto}` : `https://www.camara.leg.br${urlFoto.startsWith("/") ? "" : "/"}${urlFoto}`;
+  }
+  if (!urlFoto && Number.isFinite(idC)) {
+    urlFoto = `https://www.camara.leg.br/img/deputados/med/${idC}.jpg`;
+  }
+  return {
+    idCamara: Number.isFinite(idC) ? idC : null,
+    nome: (us.nomeEleitoral || d.nome || "").trim() || null,
+    nomeCompleto: (d.nome || "").trim() || null,
+    nomeCivil: (d.nomeCivil || "").trim() || null,
+    cpf: d.cpf != null ? String(d.cpf) : "",
+    siglaPartido: (us.siglaPartido || d.siglaPartido || "").trim() || null,
+    siglaUf: (us.siglaUf || d.siglaUf || "").trim() || null,
+    urlFoto: urlFoto || null,
+    situacao: (us.situacao || d.situacao || "").trim() || null,
+    email: (d.email || us.email || "").trim() || null,
+    gabinete: us.gabinete ?? d.gabinete ?? null,
+    municipioNascimento: (d.municipioNascimento || "").trim() || null,
+    ufNascimento: (d.ufNascimento || "").trim() || null,
+    dataNascimento: d.dataNascimento || null,
+    escolaridade: (d.escolaridade || "").trim() || null,
+    sexo: (d.sexo || "").trim() || null,
+    enrichedAt: admin.firestore.FieldValue.serverTimestamp(),
+  };
+}
+
+function hasIdentity(data) {
+  const nome = data.nome || data.nomeCompleto;
+  const partido = data.siglaPartido || data.partido;
+  const foto = data.urlFoto;
+  return Boolean(nome && partido && foto);
+}
+
+async function main() {
+  console.log(`=== enrich-firestore (${PROJECT_ID}) ===`);
+  const snap = await db.collection("deputados_federais").get();
+  const docs = snap.docs;
+  let i = 0;
+  let updated = 0;
+  let skipped = 0;
+
+  for (const docSnap of docs) {
+    i++;
+    const data = docSnap.data() || {};
+    if (hasIdentity(data)) {
+      skipped++;
+      if (i % 10 === 0) {
+        console.log(`[${i}/${docs.length}] progress — updated ${updated}, skipped ${skipped}`);
+      }
+      continue;
+    }
+
+    const depId = docSnap.id;
+    const camara = await fetchDeputado(depId);
+    await sleep(SLEEP_MS);
+
+    if (!camara) {
+      console.warn(`  [${depId}] API sem dados`);
+      if (i % 10 === 0) {
+        console.log(`[${i}/${docs.length}] progress — updated ${updated}, skipped ${skipped}`);
+      }
+      continue;
+    }
+
+    const patch = mapCamaraToFirestore(camara);
+    if (!patch || !patch.nome) {
+      console.warn(`  [${depId}] map vazio`);
+      continue;
+    }
+
+    await docSnap.ref.update(patch);
+    updated++;
+    console.log(`  [${depId}] OK — ${patch.nome}`);
+
+    if (i % 10 === 0) {
+      console.log(`[${i}/${docs.length}] progress — updated ${updated}, skipped ${skipped}`);
+    }
+  }
+
+  console.log(`\nConcluído: ${updated} atualizados, ${skipped} já tinham identidade, ${docs.length} docs no total.`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Atualização (ADC + enrich em lote)

- **`scripts/enrich-firestore.js`**: usa `admin.credential.applicationDefault()` + `projectId: fiscallizapa`. Baixa **todos** os deputados da API (`GET /deputados` paginado), faz **`set(merge: true)`** em lotes de 400 — não apaga métricas existentes. Funciona após `gcloud auth application-default login` ou com `GOOGLE_APPLICATION_CREDENTIALS`.

- **`DossiePage.jsx`**: fallback extra na query por `idCamara` com **string** (`"220593"`) além do **number**, para dados legados.

Commit: `fix(enrich): ADC + lista Câmara em batch; Dossie idCamara string fallback`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a104e531-5741-475b-a073-18bba97d95ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a104e531-5741-475b-a073-18bba97d95ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

